### PR TITLE
Document GitHub docs workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ OpenShell as the runtime.
 
 Use Python 3.10 or newer.
 
+To preview the documentation locally:
+
 ```sh
 python3 -m venv .venv
 source .venv/bin/activate
@@ -30,14 +32,21 @@ python -m pip install -r requirements-docs.txt
 zensical serve
 ```
 
-The local preview runs at <http://localhost:8000>. To build the static site:
+The local preview runs at <http://localhost:8000>. To run the same clean build
+used by CI:
 
 ```sh
-python scripts/render-dev-notes.py
-zensical build --clean --strict
+scripts/build-docs.sh
 ```
 
-The generated site is written to `site/`.
+The build script recreates `.venv-docs`, installs `requirements-docs.txt`,
+renders Dev Notes metadata, and runs `zensical build --clean --strict`. The
+generated site is written to `site/`.
+
+GitHub Actions runs the docs workflow for every pull request and `main` push.
+Pull requests validate the generated site without deploying. Pushes to `main`
+and manual workflow dispatches from `main` publish `site/` to GitHub Pages
+after validation passes.
 
 ### Dev Notes
 


### PR DESCRIPTION
## Summary
Updates the README documentation workflow to describe the GitHub-native docs path introduced by #6. The README now distinguishes local preview from the canonical clean build script, and states that GitHub Actions validates every pull request and `main` push while deploying GitHub Pages only from `main` after validation.

Closes #4

## Validation
- stale GitLab scan: `rg -n "gitlab|GitLab|\.gitlab-ci|gitlab\.io" README.md docs zensical.toml scripts .github || true` -> no matches
- test: `python3 scripts/render-dev-notes.py` -> passed
- lint: `python3 -m py_compile scripts/render-dev-notes.py` -> passed
- build: `scripts/build-docs.sh` -> passed; generated `site/`
- local site smoke: `curl -fsS http://127.0.0.1:8000/` against `python3 -m http.server 8000 --bind 127.0.0.1 --directory site` -> HTTP 200

## Risks
Low. This only updates repository-facing README guidance and does not change the generated docs site, build script, or workflow logic.

## Reviewer Notes
Focus on whether the README accurately describes `.github/workflows/docs.yml`, local preview, the canonical clean build, PR validation, and `main` GitHub Pages deployment. Backward compatibility with GitLab CI was not required.
