### PR TITLE
Generalize dependency export guidance

### DIFF
--- a/projects/python-project-template/README.md
+++ b/projects/python-project-template/README.md
@@ -40,10 +40,10 @@ uv build
 Use `uv add <package>` for runtime dependencies and `uv add --dev <package>` for
 development tools. uv updates `pyproject.toml` and `uv.lock` together.
 
-nSpect needs a resolved dependency manifest it can inspect. `uv.lock` remains
-the source of truth for installs, while `requirements.txt` is a generated,
-hash-pinned export of runtime dependencies for the scanner. Do not edit the
-export by hand. Regenerate it after every runtime dependency update:
+`uv.lock` remains the source of truth for installs. Keep `requirements.txt` as
+a generated, hash-pinned export of runtime dependencies for compatibility with
+workflows that consume requirements files. Do not edit the export by hand.
+Regenerate it after every runtime dependency update:
 
 ```sh
 uv export \


### PR DESCRIPTION
## Summary

- generalize the template's dependency-export wording
- keep `uv.lock` as the installation source of truth
- retain the hash-pinned `requirements.txt` regeneration instructions

## Why

The public template should describe the portable dependency-management pattern
without tying the documentation to a particular implementation or environment.

## Validation

- `uv run --frozen pytest` (2 passed, 100% coverage)
- verified the template contains no internal-tool wording
- `git diff --check`
