### PR TITLE
Fix docs preview workspace ordering

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -152,6 +152,12 @@ jobs:
             core.setOutput('number', String(request.number));
             core.setOutput('operation', operation);
 
+      - name: Checkout deployment tooling context
+        if: steps.request.outputs.operation != 'none'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Download preview site
         if: steps.request.outputs.operation == 'deploy'
         uses: actions/download-artifact@v8
@@ -165,12 +171,6 @@ jobs:
       - name: Create empty removal directory
         if: steps.request.outputs.operation == 'remove'
         run: mkdir preview-site
-
-      - name: Checkout deployment tooling context
-        if: steps.request.outputs.operation != 'none'
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
 
       - name: Update composite Pages branch
         if: steps.request.outputs.operation != 'none'


### PR DESCRIPTION
## Summary

- check out the trusted deployment workflow before downloading a preview artifact
- preserve the preview directory through the composite Pages branch update
- preserve the empty directory used for automatic preview teardown

## Root cause

`actions/checkout` cleaned the workspace after `preview-site` was downloaded or created. The following deployment step therefore could not find its configured source directory.

## Validation

- `git diff --check`
- parsed `.github/workflows/docs-preview-deploy.yml` with PyYAML
- `actionlint .github/workflows/docs-preview-deploy.yml`
