### PR TITLE
Add GitHub link to site header

### DIFF
--- a/docs/stylesheets/dev-notes.css
+++ b/docs/stylesheets/dev-notes.css
@@ -135,7 +135,41 @@ body {
 }
 
 .md-header__source {
-  display: none !important;
+  display: flex !important;
+  align-items: center;
+  width: auto;
+  max-width: none;
+  margin: 0 0 0 0.2rem;
+}
+
+.md-header__source .md-source {
+  display: inline-flex;
+  align-items: center;
+  color: var(--openshell-ink);
+}
+
+.md-header__source .md-source:hover,
+.md-header__source .md-source:focus-visible {
+  color: var(--openshell-accent);
+  opacity: 1;
+}
+
+.md-header__source .md-source__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.md-header__source .md-source__icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: 0;
+}
+
+.md-header__source .md-source__repository {
+  display: none;
 }
 
 .md-overlay {
@@ -329,6 +363,10 @@ body {
 
 .md-copyright__highlight a {
   color: var(--openshell-muted);
+}
+
+.md-copyright__highlight > a:last-child {
+  margin-left: auto;
 }
 
 .md-copyright__highlight a:hover,

--- a/zensical.toml
+++ b/zensical.toml
@@ -2,8 +2,9 @@
 site_name = "OpenShell Research"
 site_description = "Research engineering Dev Notes and software documentation from the OpenShell team."
 site_author = "OpenShell Research Engineering"
+repo_url = "https://github.com/NVIDIA/OpenShell-Research"
+repo_name = "OpenShell Research on GitHub"
 copyright = """
-<span><span class="openshell-footer-prompt" aria-hidden="true">&gt;_</span> OpenShell Research</span>
 <a href="https://github.com/NVIDIA/OpenShell">OpenShell on GitHub <span aria-hidden="true">↗</span></a>
 """
 docs_dir = "docs"
@@ -32,6 +33,7 @@ generator = false
 custom_dir = "overrides"
 favicon = "assets/brand/favicon.svg"
 logo = "assets/brand/openshell-mark.svg"
+icon.repo = "fontawesome/brands/github"
 features = [
   "navigation.sections",
   "navigation.indexes",


### PR DESCRIPTION
## Summary

- add an icon-only GitHub repository link to the documentation header
- remove the OpenShell Research repository link from the footer
- right-align the remaining OpenShell footer link

## Why

The repository link is clearer and less visually intrusive as a native header icon than as terminal-style footer copy.

## Validation

- `python3 tests/test_render_dev_notes.py`
- `scripts/build-docs.sh`
- local Zensical preview verified