### PR TITLE
Streamline Privacy Guard onboarding

### DIFF
--- a/projects/privacy-guard/docs/index.md
+++ b/projects/privacy-guard/docs/index.md
@@ -44,114 +44,90 @@ the provider receives the request.
 ## Quickstart
 
 This quickstart uses the built-in `RegexEngine` example to replace an email
-address and customer ID. It requires:
+address and customer ID. Before you start, install:
 
 - Python 3.11 or newer
 - `uv` 0.11 or newer
-- OpenShell and `openshell-gateway` `v0.0.90`, the version recorded in the
-  [middleware manifest](https://github.com/NVIDIA/OpenShell-Research/blob/main/projects/privacy-guard/.openshell-middleware-manifest.json)
-- a Docker or Podman backend supported by OpenShell
-- Claude Code subscription access for the final provider request; the OpenShell
-  base sandbox supplies the Claude Code binary
+- [OpenShell](https://github.com/NVIDIA/OpenShell) `v0.0.90` or a later
+  compatible version
 
-Confirm the installed command versions:
+Privacy Guard is tested with the version recorded in the
+[middleware manifest](https://github.com/NVIDIA/OpenShell-Research/blob/main/projects/privacy-guard/.openshell-middleware-manifest.json).
+A later version must support the same supervisor middleware contract.
 
-```bash
-uv --version
-openshell --version
-openshell-gateway --version
-```
+Run the following commands from a checkout of OpenShell Research.
 
-Run the commands from a checkout of OpenShell Research.
+### 1. Stop the local gateway
 
-### 1. Prepare the example
+First, check the local gateway:
 
 ```bash
-cd projects/privacy-guard/examples/regex-engine
-uv sync --locked
-uv run privacy-guard engines
+openshell status
 ```
 
-The engine list should contain:
+If the gateway is running, stop it before you change its configuration. Use the
+command for your system:
 
-```text
-regex    detect,replace
+```bash
+# macOS with Homebrew
+brew services stop openshell
+
+# Linux with a Debian or RPM package
+systemctl --user stop openshell-gateway
 ```
-
-The example files are:
-
-| File | Purpose |
-| --- | --- |
-| `patterns.yaml` | Email and customer-ID rules |
-| `privacy-guard-config.yaml` | Standalone Privacy Guard policy configuration |
-| `policy.yaml` | Complete OpenShell sandbox policy with the same configuration |
 
 ### 2. Start Privacy Guard
 
-From the example directory:
-
 ```bash
-uv run privacy-guard serve --listen 0.0.0.0:50051
+cd projects/privacy-guard/examples/regex-engine
+uv run --locked privacy-guard serve --listen 0.0.0.0:50051
 ```
 
 Keep the process running. The development server uses plaintext gRPC and
 receives request bodies. Restrict port 50051 to the host and trusted sandbox
 network.
 
-### 3. Register Privacy Guard with the gateway
+### 3. Configure and start the gateway
 
 Choose a non-loopback host IPv4 address that both the gateway and sandbox
-supervisor can reach:
+supervisor can reach.
+
+Open another terminal and return to the example directory. Replace
+`YOUR_HOST_IPV4` with the address you selected. Then update the default gateway
+configuration:
 
 ```bash
-# macOS
-ipconfig getifaddr en0
-
-# Linux
-hostname -I
-```
-
-Create a local gateway configuration:
-
-```bash
-export PRIVACY_GUARD_HOST_IP=YOUR_HOST_IPV4
-
+cd projects/privacy-guard/examples/regex-engine
 uv run privacy-guard configure-gateway \
-  --host-ip "$PRIVACY_GUARD_HOST_IP" \
-  --name privacy-guard-regex \
-  --config gateway.local.toml
+  --host-ip YOUR_HOST_IPV4 \
+  --name privacy-guard-regex
 ```
 
 Do not use `127.0.0.1`: loopback inside the sandbox supervisor does not refer to
 the host.
 
-Restart the local gateway with `gateway.local.toml`. For a Homebrew
-installation:
+The command above updates the default OpenShell gateway configuration. Next,
+use the command for your system to start the gateway in the background:
 
 ```bash
-brew services stop openshell
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/homebrew/tls"
-openshell-gateway --config "$PWD/gateway.local.toml"
+# macOS with Homebrew
+brew services start openshell
+
+# Linux with a Debian or RPM package
+systemctl --user start openshell-gateway
 ```
-
-For a Debian or RPM installation:
-
-```bash
-systemctl --user stop openshell-gateway
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/tls"
-openshell-gateway --config "$PWD/gateway.local.toml"
-```
-
-Keep the foreground gateway running.
 
 ### 4. Create a sandbox
 
-In another terminal, return to the example directory and verify the gateway:
+Open another terminal, return to the example directory, and check the gateway:
 
 ```bash
-openshell gateway select openshell
+cd projects/privacy-guard/examples/regex-engine
 openshell status
 ```
+
+This walkthrough starts Claude Code in the sandbox. To use a different harness,
+replace everything after `--` with its command.
 
 Create the example sandbox:
 

--- a/projects/privacy-guard/docs/operations.md
+++ b/projects/privacy-guard/docs/operations.md
@@ -67,24 +67,32 @@ Restrict its listen port to trusted host and sandbox networks.
 
 ## Register the service with OpenShell
 
-Choose a non-loopback IPv4 address reachable by both the local gateway and
-sandbox supervisors:
+First, check the local gateway:
 
 ```bash
-# macOS
-ipconfig getifaddr en0
-
-# Linux
-hostname -I
+openshell status
 ```
 
-Add or update a gateway registration:
+If the gateway is running, stop it before you change its configuration. Use the
+command for your system:
 
 ```bash
-export PRIVACY_GUARD_HOST_IP=YOUR_HOST_IPV4
+# macOS with Homebrew
+brew services stop openshell
 
+# Linux with a Debian or RPM package
+systemctl --user stop openshell-gateway
+```
+
+Choose a non-loopback IPv4 address reachable by both the local gateway and
+sandbox supervisors.
+
+Replace `YOUR_HOST_IPV4` with the address you selected. Then add or update the
+gateway registration:
+
+```bash
 uv run privacy-guard configure-gateway \
-  --host-ip "$PRIVACY_GUARD_HOST_IP" \
+  --host-ip YOUR_HOST_IPV4 \
   --name privacy-guard \
   --port 50051
 ```
@@ -115,45 +123,23 @@ network_middlewares:
 OpenShell does not dynamically reload middleware registrations. Restart the
 gateway after changing its configuration.
 
-## Run a local foreground gateway
+## Start the local gateway
 
-Stop the package-managed service before starting another gateway on the same
-port.
-
-### macOS with Homebrew
+Use the command for your system to start the gateway in the background:
 
 ```bash
-brew services stop openshell
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/homebrew/tls"
-openshell-gateway --config "$HOME/.config/openshell/gateway.toml"
-```
-
-Restore it after testing:
-
-```bash
+# macOS with Homebrew
 brew services start openshell
-```
 
-### Linux with a Debian or RPM package
-
-```bash
-systemctl --user stop openshell-gateway
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/tls"
-openshell-gateway --config "$HOME/.config/openshell/gateway.toml"
-```
-
-Restore it after testing:
-
-```bash
+# Linux with a Debian or RPM package
 systemctl --user start openshell-gateway
 ```
 
-For a custom gateway path, replace the `--config` argument accordingly.
+The gateway reads the default configuration that `configure-gateway` updated.
 
 ## Verify connectivity
 
 ```bash
-openshell gateway select openshell
 openshell status
 ```
 
@@ -250,8 +236,6 @@ port must be between 1 and 65535.
 | Symptom | Check |
 | --- | --- |
 | Sandbox creation reports unavailable middleware | Confirm Privacy Guard is running, the registration name matches the policy, the host IP is reachable from the sandbox network, and the port is allowed |
-| Gateway port is already in use | Stop the package-managed gateway before starting a foreground instance |
-| Foreground gateway cannot find certificates | Set `OPENSHELL_LOCAL_TLS_DIR` to the package-specific path shown above |
 | Policy config is rejected | Run `privacy-guard configuration-schema` with the same registry factory used by the server |
 | Relative Regex catalog is not found | Start Privacy Guard from the directory against which the catalog path is defined |
 | Request is denied with `privacy_guard_limit_exceeded` | Inspect Privacy Guard logs, reduce input/output/detections, simplify stages, or increase the processing timeout with OpenShell headroom |
@@ -261,17 +245,15 @@ port must be between 1 and 65535.
 
 ## Shutdown and cleanup
 
-Stop foreground Privacy Guard and gateway processes with `Ctrl-C`. Delete test
-sandboxes explicitly:
+Stop Privacy Guard with `Ctrl-C`. Delete test sandboxes explicitly:
 
 ```bash
 openshell sandbox delete SANDBOX_NAME
 ```
 
-Restore the package-managed gateway and verify connectivity:
+The gateway continues to run in the background. Verify its connection:
 
 ```bash
-openshell gateway select openshell
 openshell status
 ```
 

--- a/projects/privacy-guard/examples/custom-engine/README.md
+++ b/projects/privacy-guard/examples/custom-engine/README.md
@@ -20,28 +20,37 @@ low-level requirement.
 
 ## Prerequisites
 
-This walkthrough targets the protocol and policy schema in OpenShell `v0.0.90`,
-the version recorded in Privacy Guard's `.openshell-middleware-manifest.json`.
-Other OpenShell releases may have different middleware configuration or CLI
-syntax.
+This walkthrough was validated with OpenShell `v0.0.90`, the version recorded
+in Privacy Guard's `.openshell-middleware-manifest.json`. A later OpenShell
+release can also work if it supports the same supervisor middleware contract
+and policy schema.
 
-Before starting, have:
+Before you start, install:
 
 - Python 3.11 or newer and `uv` 0.11 or newer
-- OpenShell `v0.0.90`, installed with its package-managed local gateway
-- a running Docker or Podman backend supported by OpenShell
-- Claude Code subscription access if you want to perform the final provider call
+- [OpenShell](https://github.com/NVIDIA/OpenShell) `v0.0.90` or a later
+  compatible version
 
 The gateway lifecycle commands below cover macOS Homebrew and Linux Debian/RPM
-installations. Snap, Kubernetes, remote, and custom gateway deployments need
-equivalent service-management, TLS, and middleware-routing configuration.
+installations. For another deployment, use its equivalent gateway commands.
 
-Confirm the important versions:
+## Stop the local gateway
+
+First, check the local gateway:
 
 ```bash
-uv --version
-openshell --version
-openshell-gateway --version
+openshell status
+```
+
+If the gateway is running, stop it before you change its configuration. Use the
+command for your system:
+
+```bash
+# macOS with Homebrew
+brew services stop openshell
+
+# Linux with a Debian or RPM package
+systemctl --user stop openshell-gateway
 ```
 
 Run every command below from this example directory. In each new terminal,
@@ -49,7 +58,6 @@ repeat the `cd` command:
 
 ```bash
 cd projects/privacy-guard/examples/custom-engine
-uv sync --locked
 ```
 
 ## Inspect the custom installation
@@ -64,7 +72,7 @@ export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"
 Use the same custom registry for discovery, schema generation, and serving:
 
 ```bash
-uv run privacy-guard \
+uv run --locked privacy-guard \
   --registry-factory custom_engine:create_registry \
   engines
 
@@ -101,86 +109,46 @@ plaintext gRPC and receives potentially sensitive request bodies. Binding to
 `0.0.0.0` is necessary for the sandbox supervisor to reach it, but port 50051
 must remain restricted to the host and trusted sandbox network.
 
-## Create the gateway configuration
+## Configure and start the gateway
 
-The gateway and sandbox supervisor must both be able to reach Privacy Guard.
-Find a non-loopback IPv4 address for the physical Ethernet or Wi-Fi interface:
+Choose a non-loopback host IPv4 address that both the gateway and sandbox
+supervisor can use to reach Privacy Guard.
 
-```bash
-# macOS examples; use the interface that is actually connected.
-ipconfig getifaddr en0
-ipconfig getifaddr en1
-
-# Linux: inspect the addresses and choose the LAN address.
-hostname -I
-```
-
-In terminal 2, from this example directory, assign the selected address and
-generate the local gateway configuration:
+In terminal 2, return to the example directory. Replace `YOUR_HOST_IPV4` with
+the address you selected, then update the default gateway configuration:
 
 ```bash
-YOUR_HOST_IP=YOUR_HOST_IPV4
+cd projects/privacy-guard/examples/custom-engine
 uv run privacy-guard configure-gateway \
-  --host-ip "$YOUR_HOST_IP" \
-  --name privacy-guard-custom-engine \
-  --config gateway.local.toml
+  --host-ip YOUR_HOST_IPV4 \
+  --name privacy-guard-custom-engine
 ```
 
-Replace `YOUR_HOST_IPV4` with the address you selected. Do not use
-`127.0.0.1`, a VPN address, or `host.openshell.internal`: the foreground gateway
-process and the sandbox supervisor must both be able to resolve and reach the
-configured endpoint. This walkthrough passes `--config` to keep its generated
-file local and disposable. Without that option, the command uses OpenShell's
-`OPENSHELL_GATEWAY_CONFIG` override when set, otherwise its standard per-user
-gateway config location at `$XDG_CONFIG_HOME/openshell/gateway.toml`, normally
-`~/.config/openshell/gateway.toml`.
+Do not use `127.0.0.1`, a VPN address, or `host.openshell.internal`. The gateway
+and sandbox supervisor must both be able to reach the configured endpoint.
 
-## Restart the local gateway with middleware enabled
-
-The installed gateway does not dynamically reload middleware registrations.
-Stop its package-managed service, then run the same gateway binary in the
-foreground with `gateway.local.toml`.
-
-Run the command for your host:
+Next, use the command for your system to start the gateway in the background:
 
 ```bash
-# macOS/Homebrew
-brew services stop openshell
+# macOS with Homebrew
+brew services start openshell
 
-# Linux Debian/RPM package
-systemctl --user stop openshell-gateway
+# Linux with a Debian or RPM package
+systemctl --user start openshell-gateway
 ```
-
-Still in terminal 2, select the package-managed TLS directory for your host and
-start the gateway:
-
-```bash
-# macOS/Homebrew
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/homebrew/tls"
-
-# Linux Debian/RPM package
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/tls"
-
-openshell-gateway --config "$PWD/gateway.local.toml"
-```
-
-Run only one `export` line. Leave the foreground gateway running.
 
 ## Verify OpenShell and create the sandbox
-
-The package installer normally creates an `openshell` gateway registration.
-Reuse it; attempting to add another gateway with that name fails because it
-already exists.
 
 In terminal 3, from this example directory:
 
 ```bash
-openshell gateway select openshell
 openshell status
 ```
 
-Do not continue until status reports the foreground gateway as connected.
-Then create the sandbox:
+Do not continue until status reports that the gateway is connected.
+
+This walkthrough starts Claude Code in the sandbox. To use a different harness,
+replace everything after `--` with its command. Then create the sandbox:
 
 ```bash
 openshell sandbox create \
@@ -225,34 +193,20 @@ Exit Claude and delete the sandbox:
 openshell sandbox delete privacy-guard-custom-engine
 ```
 
-Stop the foreground gateway and Privacy Guard with `Ctrl-C`. Restore the
-package-managed gateway with the command for your host:
+Stop Privacy Guard with `Ctrl-C`. The gateway continues to run in the
+background. Verify its connection:
 
 ```bash
-# macOS/Homebrew
-brew services start openshell
-
-# Linux Debian/RPM package
-systemctl --user start openshell-gateway
-```
-
-Verify recovery and remove the generated configuration:
-
-```bash
-openshell gateway select openshell
 openshell status
-rm gateway.local.toml
 ```
 
 ## Troubleshooting
 
 - `registry factory could not be loaded`: export `PYTHONPATH` in the terminal
   running `privacy-guard`.
-- Port 17670 is already in use: the package-managed gateway was not stopped.
-- The foreground gateway cannot find certificates: use the TLS directory for
-  your platform exactly as shown above.
 - Sandbox creation reports unavailable middleware: confirm terminal 1 is still
-  running, check the IP in `gateway.local.toml`, and allow trusted sandbox
-  traffic to host port 50051.
-- Policy or middleware registration fields are rejected: confirm both
-  `openshell` and `openshell-gateway` are from `v0.0.90`.
+  running, check the IP in the default gateway configuration, and allow trusted
+  sandbox traffic to host port 50051.
+- Policy or middleware registration fields are rejected: confirm that
+  `openshell` and `openshell-gateway` use compatible versions. If the error
+  remains, use the tested `v0.0.90` release.

--- a/projects/privacy-guard/examples/regex-engine/README.md
+++ b/projects/privacy-guard/examples/regex-engine/README.md
@@ -11,67 +11,46 @@ before deployment.
 
 ## Prerequisites
 
-This walkthrough targets OpenShell `v0.0.90`, the version recorded in Privacy
-Guard's `.openshell-middleware-manifest.json`. Other releases may use different
-middleware configuration or CLI syntax.
+This walkthrough was validated with OpenShell `v0.0.90`, the version recorded
+in Privacy Guard's `.openshell-middleware-manifest.json`. A later OpenShell
+release can also work if it supports the same supervisor middleware contract
+and policy schema.
 
-Before starting, have:
+Before you start, install:
 
 - Python 3.11 or newer and `uv` 0.11 or newer
-- OpenShell `v0.0.90`, installed with its package-managed local gateway
-- a running Docker or Podman backend supported by OpenShell
-- Claude Code subscription access if you want to perform the final provider call
+- [OpenShell](https://github.com/NVIDIA/OpenShell) `v0.0.90` or a later
+  compatible version
 
 The gateway lifecycle commands below cover macOS Homebrew and Linux Debian/RPM
-installations. Snap, Kubernetes, remote, and custom gateway deployments need
-equivalent service-management, TLS, and middleware-routing configuration.
+installations. For another deployment, use its equivalent gateway commands.
 
-Confirm the versions:
+## Stop the local gateway
 
-```bash
-uv --version
-openshell --version
-openshell-gateway --version
-```
-
-Run every command below from this example directory. In each new terminal,
-repeat the `cd` command:
+First, check the local gateway:
 
 ```bash
-cd projects/privacy-guard/examples/regex-engine
-uv sync --locked
+openshell status
 ```
 
-## Inspect the built-in installation
+If the gateway is running, stop it before you change its configuration. Use the
+command for your system:
 
 ```bash
-uv run privacy-guard engines
-uv run privacy-guard configuration-schema
+# macOS with Homebrew
+brew services stop openshell
+
+# Linux with a Debian or RPM package
+systemctl --user stop openshell-gateway
 ```
-
-The first command should print one `regex` row with `detect,replace`. The schema
-should contain `RegexEngineConfig`, `RegexPatternCatalog`, `RegexRule`, and
-`RegexReplacement`.
-
-`privacy-guard-config.yaml` is the standalone Privacy Guard configuration.
-`policy.yaml` contains the same configuration inline under
-`network_middlewares`, which is the form OpenShell sends to the middleware.
-Both configurations pass `patterns.yaml` directly as the complete
-`pattern_catalog`. Privacy Guard resolves that relative path from its working
-directory, safely loads the YAML file, and validates it with the same
-`RegexPatternCatalog` model used for an inline catalog.
-
-Catalog paths must be relative `.yaml` or `.yml` paths beneath Privacy Guard's
-working directory. Absolute paths, `..` traversal, and symlinks are rejected.
-This example therefore starts Privacy Guard from this directory. Restart the
-service from the same directory whenever it is stopped.
 
 ## Start Privacy Guard
 
 In terminal 1, from this example directory:
 
 ```bash
-uv run privacy-guard serve --listen 0.0.0.0:50051
+cd projects/privacy-guard/examples/regex-engine
+uv run --locked privacy-guard serve --listen 0.0.0.0:50051
 ```
 
 Leave this terminal running. The development server is unauthenticated
@@ -79,77 +58,46 @@ plaintext gRPC and receives potentially sensitive request bodies. Binding to
 `0.0.0.0` is necessary for the sandbox supervisor to reach it, but port 50051
 must remain restricted to the host and trusted sandbox network.
 
-## Create the gateway configuration
+## Configure and start the gateway
 
-Find a non-loopback IPv4 address for the physical Ethernet or Wi-Fi interface:
+Choose a non-loopback host IPv4 address that both the gateway and sandbox
+supervisor can reach.
 
-```bash
-# macOS examples; use the interface that is actually connected.
-ipconfig getifaddr en0
-ipconfig getifaddr en1
-
-# Linux: inspect the addresses and choose the LAN address.
-hostname -I
-```
-
-In terminal 2, from this example directory, assign the selected address:
+In terminal 2, return to the example directory. Replace `YOUR_HOST_IPV4` with
+the address you selected, then update the default gateway configuration:
 
 ```bash
-YOUR_HOST_IP=YOUR_HOST_IPV4
+cd projects/privacy-guard/examples/regex-engine
 uv run privacy-guard configure-gateway \
-  --host-ip "$YOUR_HOST_IP" \
-  --name privacy-guard-regex \
-  --config gateway.local.toml
+  --host-ip YOUR_HOST_IPV4 \
+  --name privacy-guard-regex
 ```
 
-Replace `YOUR_HOST_IPV4` with the address you selected. Do not use
-`127.0.0.1`, a VPN address, or `host.openshell.internal`: the foreground gateway
-process and the sandbox supervisor must both be able to resolve and reach the
-configured endpoint. This walkthrough passes `--config` to keep its generated
-file local and disposable. Without that option, the command uses OpenShell's
-`OPENSHELL_GATEWAY_CONFIG` override when set, otherwise its standard per-user
-gateway config location at `$XDG_CONFIG_HOME/openshell/gateway.toml`, normally
-`~/.config/openshell/gateway.toml`.
+Do not use `127.0.0.1`, a VPN address, or `host.openshell.internal`. The gateway
+and sandbox supervisor must both be able to reach the configured endpoint.
 
-## Restart the local gateway with middleware enabled
-
-The installed gateway does not dynamically reload middleware registrations.
-Stop its package-managed service with the command for your host:
+Next, use the command for your system to start the gateway in the background:
 
 ```bash
-# macOS/Homebrew
-brew services stop openshell
+# macOS with Homebrew
+brew services start openshell
 
-# Linux Debian/RPM package
-systemctl --user stop openshell-gateway
+# Linux with a Debian or RPM package
+systemctl --user start openshell-gateway
 ```
-
-Still in terminal 2, select the package-managed TLS directory for your host and
-start the gateway:
-
-```bash
-# macOS/Homebrew
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/homebrew/tls"
-
-# Linux Debian/RPM package
-export OPENSHELL_LOCAL_TLS_DIR="$HOME/.local/state/openshell/tls"
-
-openshell-gateway --config "$PWD/gateway.local.toml"
-```
-
-Run only one `export` line. Leave the foreground gateway running.
 
 ## Verify OpenShell and create the sandbox
 
 In terminal 3, from this example directory:
 
 ```bash
-openshell gateway select openshell
 openshell status
 ```
 
-Do not continue until status reports the foreground gateway as connected.
-Then create the sandbox:
+Do not continue until status reports that the gateway is connected.
+
+This walkthrough starts Claude Code in the sandbox. To use a different harness,
+replace everything after `--` with its command. Then create the sandbox:
 
 ```bash
 openshell sandbox create \
@@ -192,32 +140,18 @@ Exit Claude and delete the sandbox:
 openshell sandbox delete privacy-guard-regex
 ```
 
-Stop the foreground gateway and Privacy Guard with `Ctrl-C`. Restore the
-package-managed gateway with the command for your host:
+Stop Privacy Guard with `Ctrl-C`. The gateway continues to run in the
+background. Verify its connection:
 
 ```bash
-# macOS/Homebrew
-brew services start openshell
-
-# Linux Debian/RPM package
-systemctl --user start openshell-gateway
-```
-
-Verify recovery and remove the generated gateway file:
-
-```bash
-openshell gateway select openshell
 openshell status
-rm gateway.local.toml
 ```
 
 ## Troubleshooting
 
-- Port 17670 is already in use: the package-managed gateway was not stopped.
-- The foreground gateway cannot find certificates: use the TLS directory for
-  your platform exactly as shown above.
 - Sandbox creation reports unavailable middleware: confirm terminal 1 is still
-  running, check the IP in `gateway.local.toml`, and allow trusted sandbox
-  traffic to host port 50051.
-- Policy or middleware registration fields are rejected: confirm both
-  `openshell` and `openshell-gateway` are from `v0.0.90`.
+  running, check the IP in the default gateway configuration, and allow trusted
+  sandbox traffic to host port 50051.
+- Policy or middleware registration fields are rejected: confirm that
+  `openshell` and `openshell-gateway` use compatible versions. If the error
+  remains, use the tested `v0.0.90` release.

--- a/projects/privacy-guard/tests/examples/test_custom_engine.py
+++ b/projects/privacy-guard/tests/examples/test_custom_engine.py
@@ -127,14 +127,20 @@ def test_openshell_walkthrough_uses_the_custom_registry_and_current_policy() -> 
     assert config["on_detection"]["action"] == "detect"
     assert "--registry-factory custom_engine:create_registry" in readme
     assert "cd projects/privacy-guard/examples/custom-engine" in readme
+    assert "uv sync --locked" not in readme
+    assert "uv run --locked privacy-guard" in readme
     assert 'export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"' in readme
     assert "uv run privacy-guard configure-gateway" in readme
-    assert '--host-ip "$YOUR_HOST_IP"' in readme
+    assert "--host-ip YOUR_HOST_IPV4" in readme
     assert "--name privacy-guard-custom-engine" in readme
-    assert "--config gateway.local.toml" in readme
+    assert "--config" not in readme
+    assert "brew services stop openshell" in readme
+    assert "brew services start openshell" in readme
+    assert "systemctl --user stop openshell-gateway" in readme
+    assert "systemctl --user start openshell-gateway" in readme
+    assert "openshell-gateway --config" not in readme
     assert 'sed "s/REPLACE_WITH_HOST_IP/' not in readme
     assert not (EXAMPLE_DIRECTORY / "gateway.toml").exists()
-    assert "openshell gateway select openshell" in readme
     assert "openshell gateway add" not in readme
     assert "OpenShell `v0.0.90`" in readme
     assert "transformed:false" in readme

--- a/projects/privacy-guard/tests/examples/test_regex_engine.py
+++ b/projects/privacy-guard/tests/examples/test_regex_engine.py
@@ -99,14 +99,19 @@ def test_regex_walkthrough_uses_current_policy_and_gateway_schema() -> None:
     assert stage_config["engine"] == "regex"
     assert stage_config["pattern_catalog"] == "patterns.yaml"
     RegexPatternCatalog.model_validate(catalog)
-    assert "uv run privacy-guard serve --listen 0.0.0.0:50051" in readme
+    assert "uv sync --locked" not in readme
+    assert "uv run --locked privacy-guard serve --listen 0.0.0.0:50051" in readme
     assert "uv run privacy-guard configure-gateway" in readme
-    assert '--host-ip "$YOUR_HOST_IP"' in readme
+    assert "--host-ip YOUR_HOST_IPV4" in readme
     assert "--name privacy-guard-regex" in readme
-    assert "--config gateway.local.toml" in readme
+    assert "--config" not in readme
+    assert "brew services stop openshell" in readme
+    assert "brew services start openshell" in readme
+    assert "systemctl --user stop openshell-gateway" in readme
+    assert "systemctl --user start openshell-gateway" in readme
+    assert "openshell-gateway --config" not in readme
     assert 'sed "s/REPLACE_WITH_HOST_IP/' not in readme
     assert not (EXAMPLE_DIRECTORY / "gateway.toml").exists()
-    assert "openshell gateway select openshell" in readme
     assert "openshell gateway add" not in readme
     assert "OpenShell `v0.0.90`" in readme
     assert "transformed:true" in readme


### PR DESCRIPTION
## Summary

- simplify the Privacy Guard quickstart and operations workflow
- update the default gateway configuration and run the gateway in the background
- remove redundant setup, version-check, IP-discovery, foreground gateway, and TLS steps
- clarify OpenShell version compatibility and harness choice
- align the regex and custom-engine walkthroughs
- update example tests to enforce the streamlined commands

## Impact

Readers can reach a working Privacy Guard example with fewer commands and a
consistent gateway workflow. The revised prose follows Simplified Technical
English while preserving security and compatibility guidance.

## Validation

- `make check` — 242 tests passed
- `python3 tests/test_render_dev_notes.py` — 11 tests passed
- `scripts/build-docs.sh` — strict build completed with no issues
