### PR TITLE
Highlight Privacy Guard experimental warning

### DIFF
--- a/projects/privacy-guard/docs/index.md
+++ b/projects/privacy-guard/docs/index.md
@@ -6,6 +6,12 @@ agent_markdown: true
 
 # Privacy Guard
 
+!!! warning "Experimental software"
+
+    Privacy Guard is a proof of concept, not a guarantee that sensitive data
+    cannot leak. It currently protects only provider-bound network requests
+    that OpenShell routes through this middleware.
+
 Privacy Guard is an OpenShell supervisor middleware. It examines provider-bound
 HTTP request bodies before OpenShell attaches provider credentials. A policy can
 instruct Privacy Guard to:
@@ -15,10 +21,6 @@ instruct Privacy Guard to:
 | `detect` | Allow the original body and report bounded findings |
 | `block` | Deny the request and report bounded findings |
 | `replace` | Allow a body produced by the configured replacement engines and report bounded findings |
-
-> **Experimental:** Privacy Guard is a proof of concept, not a guarantee that
-> sensitive data cannot leak. It currently protects only provider-bound network
-> requests that OpenShell routes through this middleware.
 
 Privacy Guard does not intercept prompts, tool output, transcripts, or session
 history before a harness writes them to disk. Those files may contain raw

--- a/zensical.toml
+++ b/zensical.toml
@@ -52,6 +52,8 @@ nav = [
 homepage = "."
 generator = false
 
+[project.markdown_extensions.admonition]
+
 [project.theme]
 custom_dir = "overrides"
 favicon = "assets/brand/favicon.svg"


### PR DESCRIPTION
## Summary

- move the Privacy Guard experimental notice to the top of the documentation landing page
- render the notice as a prominent warning admonition
- enable the Zensical admonition Markdown extension

## Why

Privacy Guard is a proof of concept with a limited protection boundary. Readers should see that limitation before the product overview and quickstart content.

## Validation

- `python3 tests/test_render_dev_notes.py`
- `scripts/build-docs.sh`
- verified the built `/documentation/privacy-guard/` page renders an `admonition warning` at the top
