### PR TITLE
Check license headers across repository

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,33 @@
+name: License headers
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-headers-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check license headers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Check license headers
+        run: python scripts/update_license_headers.py --check

--- a/projects/egress-gate/analysis/render_latency_plot.py
+++ b/projects/egress-gate/analysis/render_latency_plot.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Render the Egress Gate latency proof-of-concept figure as deterministic SVG."""
 
 from __future__ import annotations

--- a/projects/egress-gate/examples/class-based-gate/keyword_gate.py
+++ b/projects/egress-gate/examples/class-based-gate/keyword_gate.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """A minimal class-based Egress Gate implementation."""
 
 from typing import Literal

--- a/projects/egress-gate/examples/custom-gate/keyword_gate.py
+++ b/projects/egress-gate/examples/custom-gate/keyword_gate.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """A minimal custom Egress Gate implementation."""
 
 from typing import Literal

--- a/projects/egress-gate/scripts/check.sh
+++ b/projects/egress-gate/scripts/check.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."

--- a/projects/egress-gate/src/egress_gate/__init__.py
+++ b/projects/egress-gate/src/egress_gate/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Egress Gate: an OpenShell supervisor middleware. See the package README."""

--- a/projects/egress-gate/src/egress_gate/base.py
+++ b/projects/egress-gate/src/egress_gate/base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Package-wide base class for validated, immutable domain objects."""
 
 from pydantic import BaseModel, ConfigDict

--- a/projects/egress-gate/src/egress_gate/cli.py
+++ b/projects/egress-gate/src/egress_gate/cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Egress Gate command-line application."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/config.py
+++ b/projects/egress-gate/src/egress_gate/config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Strict Egress Gate policy configuration."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/constants.py
+++ b/projects/egress-gate/src/egress_gate/constants.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Package-wide Egress Gate constants and operational limits.
 
 Keep this module dependency-free within the package: it must not import from

--- a/projects/egress-gate/src/egress_gate/errors.py
+++ b/projects/egress-gate/src/egress_gate/errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Content-safe failures shared across Egress Gate trust boundaries."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/gates/__init__.py
+++ b/projects/egress-gate/src/egress_gate/gates/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Public Egress Gate authoring and built-in gate surface."""
 
 from egress_gate.gates.base import (

--- a/projects/egress-gate/src/egress_gate/gates/base.py
+++ b/projects/egress-gate/src/egress_gate/gates/base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Trusted request-level gate extension contract."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/gates/regex.py
+++ b/projects/egress-gate/src/egress_gate/gates/regex.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Bounded regex catalog compilation, matching, and gate evaluation."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/gates/regex_scans.py
+++ b/projects/egress-gate/src/egress_gate/gates/regex_scans.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Public action and source configuration for regex request scans."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/gates/registry.py
+++ b/projects/egress-gate/src/egress_gate/gates/registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Gate registration and lazy policy-schema construction."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/gateway_config.py
+++ b/projects/egress-gate/src/egress_gate/gateway_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenShell gateway registration management for the command-line application."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/logging.py
+++ b/projects/egress-gate/src/egress_gate/logging.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Native Python logging configuration for Egress Gate."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request.py
+++ b/projects/egress-gate/src/egress_gate/request.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Immutable request and mutation models shared by Egress Gate components."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request_content/__init__.py
+++ b/projects/egress-gate/src/egress_gate/request_content/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Public structured request-content parsing surface."""
 
 from egress_gate.request_content.json import (

--- a/projects/egress-gate/src/egress_gate/request_content/_json_parser.py
+++ b/projects/egress-gate/src/egress_gate/request_content/_json_parser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Private bounded parser for source-aware strict JSON documents."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request_content/json.py
+++ b/projects/egress-gate/src/egress_gate/request_content/json.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Strict source-aware JSON request-content parsing and selection."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request_content/json_values.py
+++ b/projects/egress-gate/src/egress_gate/request_content/json_values.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared JSON value kinds used by public documents and the private parser."""
 
 from enum import StrEnum

--- a/projects/egress-gate/src/egress_gate/request_content/messages.py
+++ b/projects/egress-gate/src/egress_gate/request_content/messages.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Normalized agent message blocks derived from structured JSON content."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request_content/parsers.py
+++ b/projects/egress-gate/src/egress_gate/request_content/parsers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Gate-agnostic parsers for text-bearing request content."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/request_content/text.py
+++ b/projects/egress-gate/src/egress_gate/request_content/text.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared immutable values for parsed request text and its replacements."""
 
 from dataclasses import dataclass

--- a/projects/egress-gate/src/egress_gate/request_processor.py
+++ b/projects/egress-gate/src/egress_gate/request_processor.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Ordered gate execution over one mutable-current immutable request value."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/result.py
+++ b/projects/egress-gate/src/egress_gate/result.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Immutable gate evaluations and Egress Gate result models.
 
 These models deliberately contain no protobuf or gRPC types. ``SourcedFinding``

--- a/projects/egress-gate/src/egress_gate/service/__init__.py
+++ b/projects/egress-gate/src/egress_gate/service/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """gRPC transport and servicer for the Egress Gate middleware."""
 
 from egress_gate.service.server import EgressGateServer

--- a/projects/egress-gate/src/egress_gate/service/server.py
+++ b/projects/egress-gate/src/egress_gate/service/server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Programmatic Egress Gate gRPC server lifecycle."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/service/servicer.py
+++ b/projects/egress-gate/src/egress_gate/service/servicer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """gRPC boundary for the protobuf-free Egress Gate pipeline processor."""
 
 from __future__ import annotations

--- a/projects/egress-gate/src/egress_gate/string_validators.py
+++ b/projects/egress-gate/src/egress_gate/string_validators.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Reusable string validators and the field types built from them."""
 
 from typing import Annotated

--- a/projects/egress-gate/src/egress_gate/timeout.py
+++ b/projects/egress-gate/src/egress_gate/timeout.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """A shared monotonic timeout for one request-pipeline run."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/__init__.py
+++ b/projects/egress-gate/tests/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Egress Gate test package."""

--- a/projects/egress-gate/tests/gates/__init__.py
+++ b/projects/egress-gate/tests/gates/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Gate contract and built-in gate tests."""

--- a/projects/egress-gate/tests/gates/test_base.py
+++ b/projects/egress-gate/tests/gates/test_base.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contract tests for trusted request-level gates."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/gates/test_function_gate.py
+++ b/projects/egress-gate/tests/gates/test_function_gate.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the resource-free function-gate authoring helper."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/gates/test_regex.py
+++ b/projects/egress-gate/tests/gates/test_regex.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Behavior, scans, actions, safety, caching, and concurrency tests for regex."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/gates/test_registry.py
+++ b/projects/egress-gate/tests/gates/test_registry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Registry sealing and exact pipeline-schema tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/request_content/__init__.py
+++ b/projects/egress-gate/tests/request_content/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Structured request-content tests."""

--- a/projects/egress-gate/tests/request_content/test_json.py
+++ b/projects/egress-gate/tests/request_content/test_json.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contracts for strict JSON selection and source-preserving replacement."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/request_content/test_messages.py
+++ b/projects/egress-gate/tests/request_content/test_messages.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contracts for normalized message blocks backed by JSON text nodes."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/request_content/test_parsers.py
+++ b/projects/egress-gate/tests/request_content/test_parsers.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contracts for reusable request-content text parsers."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/service/__init__.py
+++ b/projects/egress-gate/tests/service/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Egress Gate service tests."""

--- a/projects/egress-gate/tests/service/test_grpc_integration.py
+++ b/projects/egress-gate/tests/service/test_grpc_integration.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Loopback coverage for the generated OpenShell gRPC service."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/service/test_server.py
+++ b/projects/egress-gate/tests/service/test_server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Programmatic Egress Gate server lifecycle and transport-isolation tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/service/test_servicer.py
+++ b/projects/egress-gate/tests/service/test_servicer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Transport-boundary tests for the canonical OpenShell protobuf adapter."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_cli.py
+++ b/projects/egress-gate/tests/test_cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Command-line tests for Egress Gate discovery and policy schema surfaces."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_config.py
+++ b/projects/egress-gate/tests/test_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Strict pipeline configuration tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_errors.py
+++ b/projects/egress-gate/tests/test_errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 
 from egress_gate.errors import (

--- a/projects/egress-gate/tests/test_gateway_config.py
+++ b/projects/egress-gate/tests/test_gateway_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenShell gateway registration management tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_logging.py
+++ b/projects/egress-gate/tests/test_logging.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Egress Gate logging configuration tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_request.py
+++ b/projects/egress-gate/tests/test_request.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Focused boundary tests for the protobuf-free request domain models."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_request_processor.py
+++ b/projects/egress-gate/tests/test_request_processor.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Ordered current-request execution and decision-provenance tests."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_result.py
+++ b/projects/egress-gate/tests/test_result.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Focused invariant and boundary tests for Egress Gate result models."""
 
 from __future__ import annotations

--- a/projects/egress-gate/tests/test_timeout.py
+++ b/projects/egress-gate/tests/test_timeout.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the shared gate-pipeline timeout."""
 
 from time import monotonic

--- a/projects/egress-gate/tests/test_typing_policy.py
+++ b/projects/egress-gate/tests/test_typing_policy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """AST-enforced type-safety policy for handwritten Python."""
 
 from __future__ import annotations

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/__init__.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Create and update version-matched OpenShell middleware projects."""
 
 __version__ = "0.1.0"

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Typer command-line interface for OpenShell middleware projects."""
 
 from __future__ import annotations

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/generator.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/generator.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Safe, version-matched project creation and updates."""
 
 from __future__ import annotations

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/src/package/__init__.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/src/package/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """__PROJECT_NAME__: an OpenShell supervisor middleware."""

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/src/package/server.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/src/package/server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Pass-through OpenShell supervisor middleware server."""
 
 from __future__ import annotations

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/tests/test_server.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/templates/python/tests/test_server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 
 import grpc

--- a/projects/openshell-middleware-manager/tests/test_cli.py
+++ b/projects/openshell-middleware-manager/tests/test_cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 
 from typer.testing import CliRunner

--- a/projects/openshell-middleware-manager/tests/test_generator.py
+++ b/projects/openshell-middleware-manager/tests/test_generator.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import ctypes

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/__init__.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Trusted native controller for the Reachy Mini OpenShell agent."""
 
 from reachy_mini_openshell_controller.settings import ControllerSettings

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/app.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/app.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Reachy Mini Apps lifecycle integration for the OpenShell agent."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/audio.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/audio.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Small NumPy-only codec helpers for robot PCM audio."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/bridge.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/bridge.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Bidirectional audio bridge between Reachy hardware and the sandbox agent."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/camera_adapter.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/camera_adapter.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Narrow trusted HTTP adapter for one-frame Reachy camera capture."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/openshell.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/openshell.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Fixed OpenShell lifecycle commands used by the trusted Reachy App."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/settings.py
+++ b/projects/reachy-mini-openshell/native-controller/src/reachy_mini_openshell_controller/settings.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Configuration for the trusted native controller."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/native-controller/tests/test_audio.py
+++ b/projects/reachy-mini-openshell/native-controller/tests/test_audio.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the trusted native audio bridge."""
 
 # ruff: noqa: D103

--- a/projects/reachy-mini-openshell/native-controller/tests/test_camera_adapter.py
+++ b/projects/reachy-mini-openshell/native-controller/tests/test_camera_adapter.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the trusted native camera adapter."""
 
 # ruff: noqa: D101, D102, D103, D107

--- a/projects/reachy-mini-openshell/native-controller/tests/test_openshell.py
+++ b/projects/reachy-mini-openshell/native-controller/tests/test_openshell.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for fixed native OpenShell lifecycle commands."""
 
 # ruff: noqa: D103

--- a/projects/reachy-mini-openshell/scripts/fake_openai_backend.py
+++ b/projects/reachy-mini-openshell/scripts/fake_openai_backend.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tiny OpenAI-compatible backend for local Reachy conversation smoke tests."""
 
 import io

--- a/projects/reachy-mini-openshell/scripts/smoke-local-stt.sh
+++ b/projects/reachy-mini-openshell/scripts/smoke-local-stt.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/projects/reachy-mini-openshell/scripts/start-local.sh
+++ b/projects/reachy-mini-openshell/scripts/start-local.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Reachy Mini conversation app fork for OpenShell demos."""
 
 from importlib.metadata import PackageNotFoundError, version

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/__main__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/__main__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from reachy_mini_conversation_app.main import main
 
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Audio helpers for Reachy Mini speech playback and movement."""

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Moves head given audio samples."""
 
 import time

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/mic_phrase.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/mic_phrase.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Microphone phrase buffering for local-STT transcription."""
 
 from typing import Any

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/pcm.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/pcm.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """PCM and WAV helpers shared by realtime and local-STT backends."""
 
 import io

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/speech_tapper.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/audio/speech_tapper.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 import math
 from typing import Any, Dict, List

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/backend_check.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/backend_check.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Backend configuration and endpoint smoke checks for the conversation app."""
 
 import asyncio

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/backend_runtime.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/backend_runtime.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Final, Literal
 from dataclasses import dataclass
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/camera_worker.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/camera_worker.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Camera worker thread with frame buffering and face tracking.
 
 Ported from main_works.py camera_worker() function to provide:

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/chat_completions.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/chat_completions.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Chat Completions text/tool loop for the local-STT backend."""
 
 import re

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/config.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import sys

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/console.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/console.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Bidirectional local audio stream for Reachy Mini audio."""
 
 import time

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/conversation_stream.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/conversation_stream.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import uuid
 import base64

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/dance_emotion_moves.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/dance_emotion_moves.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Dance and emotion moves for the movement queue system.
 
 This module implements dance moves and emotions as Move objects that can be queued

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/goto_queue_move.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/goto_queue_move.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Queued goto move for direct head, antenna, and body-yaw targets."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/local_stt_backend.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/local_stt_backend.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Local-STT backend adapter for STT -> Chat Completions/tools -> TTS."""
 
 from typing import Any

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/main.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Entrypoint for the Reachy Mini conversation app."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/media_result_processor.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/media_result_processor.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Process raw local-tool media before any result reaches a conversation model."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/moves.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/moves.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Movement system with sequential primary moves and additive secondary moves.
 
 Design overview

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/native_app.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/native_app.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Native Reachy Mini Apps integration for local robot installations."""
 
 import asyncio

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Profiles for Reachy Mini conversation app."""

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Locked Reachy OpenShell profile."""

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/scan_scene.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/scan_scene.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Record a synchronized Reachy sweep and return representative vision frames."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/sweep_look.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/profiles/_reachy_mini_conversation_app_locked_profile/sweep_look.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/prompts.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/prompts.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import logging
 from pathlib import Path

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/realtime_backends.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/realtime_backends.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any
 from dataclasses import dataclass

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/rest_tool_transport.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/rest_tool_transport.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Direct, policy-aware Reachy REST tool transport."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/robot_runtime.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/robot_runtime.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Reusable lifecycle for a Reachy Mini robot and its local workers."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/sandbox_audio.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/sandbox_audio.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Headless audio service for the OpenShell-hosted conversation agent."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/sandbox_control.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/sandbox_control.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Idempotent lifecycle control for the agent process inside a sandbox."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/speech_endpoints.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/speech_endpoints.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenAI-compatible STT and TTS endpoint helpers for local-STT mode."""
 
 from typing import Any, Callable

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tool_transport.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tool_transport.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tool transport abstraction and direct in-process implementation."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tools loaded by the locked Reachy OpenShell profile."""

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/background_tool_manager.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/background_tool_manager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Background tool orchestrator for non-blocking tool execution.
 
 Allows tools to run long operations asynchronously while the robot

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/camera.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/camera.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import base64
 import asyncio
 import logging

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 import abc
 import json

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/dance.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/dance.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/do_nothing.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/do_nothing.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/head_tracking.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/head_tracking.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/move_head.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/move_head.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict, Tuple, Literal
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/stop_dance.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/stop_dance.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/stop_emotion.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/stop_emotion.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from typing import Any, Dict
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/task_cancel.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/task_cancel.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tool cancel tool - cancel running background tools."""
 
 import logging

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/task_status.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/task_status.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tool status tool - check status of background tools."""
 
 import time

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/tool_constants.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/tools/tool_constants.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import Enum
 
 

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/utils.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 import logging
 import argparse

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/__init__.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Optional vision integrations for the Reachy Mini conversation app."""

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/processors.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/processors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import time
 import base64

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/yolo_head_tracker.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision/yolo_head_tracker.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 import logging
 from typing import Tuple

--- a/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision_router.py
+++ b/projects/reachy-mini-openshell/src/reachy_mini_conversation_app/vision_router.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Single-model routing for camera and scene-scan image analysis."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/style.css
+++ b/projects/reachy-mini-openshell/style.css
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 :root {
   --bg: #060b1a;
   --bg-2: #071023;

--- a/projects/reachy-mini-openshell/tests/audio/test_head_wobbler.py
+++ b/projects/reachy-mini-openshell/tests/audio/test_head_wobbler.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Regression tests for the audio-driven head wobble behaviour."""
 
 import math

--- a/projects/reachy-mini-openshell/tests/audio/test_pcm.py
+++ b/projects/reachy-mini-openshell/tests/audio/test_pcm.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import wave
 from pathlib import Path
 

--- a/projects/reachy-mini-openshell/tests/conftest.py
+++ b/projects/reachy-mini-openshell/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Pytest configuration for path setup."""
 
 import os

--- a/projects/reachy-mini-openshell/tests/test_backend_check.py
+++ b/projects/reachy-mini-openshell/tests/test_backend_check.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from typing import Any
 from argparse import Namespace

--- a/projects/reachy-mini-openshell/tests/test_backend_runtime.py
+++ b/projects/reachy-mini-openshell/tests/test_backend_runtime.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 
 import reachy_mini_conversation_app.config as config_mod

--- a/projects/reachy-mini-openshell/tests/test_camera_policy.py
+++ b/projects/reachy-mini-openshell/tests/test_camera_policy.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Regression tests for the two explicit camera policy modes."""
 
 # ruff: noqa: D103

--- a/projects/reachy-mini-openshell/tests/test_chat_completions_media.py
+++ b/projects/reachy-mini-openshell/tests/test_chat_completions_media.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for camera media passed through the Chat Completions tool loop."""
 
 import json

--- a/projects/reachy-mini-openshell/tests/test_config.py
+++ b/projects/reachy-mini-openshell/tests/test_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 import json

--- a/projects/reachy-mini-openshell/tests/test_conversation_stream.py
+++ b/projects/reachy-mini-openshell/tests/test_conversation_stream.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import base64
 import random

--- a/projects/reachy-mini-openshell/tests/test_fake_openai_backend.py
+++ b/projects/reachy-mini-openshell/tests/test_fake_openai_backend.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import wave
 import importlib.util
 from typing import Any

--- a/projects/reachy-mini-openshell/tests/test_local_stt_backend.py
+++ b/projects/reachy-mini-openshell/tests/test_local_stt_backend.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/projects/reachy-mini-openshell/tests/test_main.py
+++ b/projects/reachy-mini-openshell/tests/test_main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 from typing import Any
 

--- a/projects/reachy-mini-openshell/tests/test_media_result_processor.py
+++ b/projects/reachy-mini-openshell/tests/test_media_result_processor.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the optional local raw-media boundary."""
 
 import base64

--- a/projects/reachy-mini-openshell/tests/test_mic_phrase.py
+++ b/projects/reachy-mini-openshell/tests/test_mic_phrase.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 
 from reachy_mini_conversation_app.audio.mic_phrase import MicPhraseBuffer, MicPhraseConfig

--- a/projects/reachy-mini-openshell/tests/test_moves_delivery.py
+++ b/projects/reachy-mini-openshell/tests/test_moves_delivery.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 from typing import Any
 

--- a/projects/reachy-mini-openshell/tests/test_package.py
+++ b/projects/reachy-mini-openshell/tests/test_package.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import reachy_mini_conversation_app
 
 

--- a/projects/reachy-mini-openshell/tests/test_prompts.py
+++ b/projects/reachy-mini-openshell/tests/test_prompts.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for locked Realtime session instructions."""
 
 from reachy_mini_conversation_app.prompts import get_session_instructions

--- a/projects/reachy-mini-openshell/tests/test_realtime_backends.py
+++ b/projects/reachy-mini-openshell/tests/test_realtime_backends.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 
 import pytest

--- a/projects/reachy-mini-openshell/tests/test_rest_tool_transport.py
+++ b/projects/reachy-mini-openshell/tests/test_rest_tool_transport.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the fixed Reachy daemon REST transport."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/tests/test_robot_runtime.py
+++ b/projects/reachy-mini-openshell/tests/test_robot_runtime.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 from typing import Any
 from pathlib import Path

--- a/projects/reachy-mini-openshell/tests/test_sandbox_audio.py
+++ b/projects/reachy-mini-openshell/tests/test_sandbox_audio.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the sandbox audio WebSocket service."""
 
 # ruff: noqa: D101, D102, D103, D107

--- a/projects/reachy-mini-openshell/tests/test_sandbox_control.py
+++ b/projects/reachy-mini-openshell/tests/test_sandbox_control.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for in-sandbox lifecycle control."""
 
 # ruff: noqa: D103

--- a/projects/reachy-mini-openshell/tests/test_speech_endpoints.py
+++ b/projects/reachy-mini-openshell/tests/test_speech_endpoints.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 
 import numpy as np

--- a/projects/reachy-mini-openshell/tests/test_tool_transports.py
+++ b/projects/reachy-mini-openshell/tests/test_tool_transports.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for local and routed tool transports."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/tests/test_vision_router.py
+++ b/projects/reachy-mini-openshell/tests/test_vision_router.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for single-model camera and scene-scan routing."""
 
 from typing import Any

--- a/projects/reachy-mini-openshell/tests/tools/test_background_tool_manager.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_background_tool_manager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for BackgroundToolManager."""
 
 from __future__ import annotations

--- a/projects/reachy-mini-openshell/tests/tools/test_camera.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_camera.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the camera tool's routed vision behavior."""
 
 from typing import Any

--- a/projects/reachy-mini-openshell/tests/tools/test_core_tools.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_core_tools.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for profile tool registration and dependency-aware exposure."""
 
 from typing import Any, cast

--- a/projects/reachy-mini-openshell/tests/tools/test_move_head.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_move_head.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for ordered Reachy Mini head movements."""
 
 from unittest.mock import MagicMock

--- a/projects/reachy-mini-openshell/tests/tools/test_play_emotion.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_play_emotion.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, cast
 
 import pytest

--- a/projects/reachy-mini-openshell/tests/tools/test_scan_scene.py
+++ b/projects/reachy-mini-openshell/tests/tools/test_scan_scene.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for synchronized Reachy scene scanning and recording."""
 
 import base64

--- a/projects/reachy-mini-openshell/tests/vision/test_processors.py
+++ b/projects/reachy-mini-openshell/tests/vision/test_processors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the vision processing module."""
 
 import time

--- a/projects/robotics-policy-prover/src/styles.css
+++ b/projects/robotics-policy-prover/src/styles.css
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 :root {
   color-scheme: light;
   font-family:

--- a/scripts/update_license_headers.py
+++ b/scripts/update_license_headers.py
@@ -19,6 +19,7 @@ SKIP_PATTERNS = frozenset(
         ".egg-info",
         ".git",
         ".pytest_cache",
+        "/bindings/",
         "node_modules",
         ".venv",
         "venv",
@@ -396,7 +397,7 @@ if __name__ == "__main__":
     total_processed = total_updated = total_skipped = 0
 
     # Process root-level directories
-    for folder in ["docs", "scripts", "tests_e2e"]:
+    for folder in ["dev-tools", "docs", "projects", "scripts", "tests_e2e"]:
         folder_path = repo_path / folder
         if not folder_path.exists():
             continue


### PR DESCRIPTION
## Summary

- add a dedicated CI check for repository license headers
- extend the existing updater to cover handwritten code under `projects/`
- exclude generated binding directories from header enforcement
- apply the standard SPDX header to existing Python, shell, and CSS project files

## Why

License-header enforcement was available as a local script but was not running in CI and did not cover project code. This makes the policy automatic and brings the existing eligible files into compliance.

## Validation

- `python3 scripts/update_license_headers.py --check` (173 eligible files)
- `git diff --check`
- Egress Gate full checks: 324 tests passed, formatting, lint, type checking, and audit passed
- OpenShell Middleware Manager full checks: 86 tests passed, formatting, lint, type checking, coverage, and build passed
- Reachy Mini: Ruff, Python compilation, and shell syntax passed; its full locked environment is macOS-only
- Robotics Policy Prover: frontend build and two-viewport visual verification passed; Rust tests require `cmake`, which was unavailable on the validation host
