### PR TITLE
Namespace OAR release tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ read `docs/development/index.md`.
   workflow is documented; regenerate exports with `uv`, never by hand.
 - Never commit credentials or populated `.env` files. Document configuration in
   `.env.example`.
+- Namespace release tags with a project label so versions from different
+  projects do not collide. OpenShell Agent Runner tags use `oar-vX.Y.Z`.
 - Do not hand-edit generated Dev Notes cards, bylines, or navigation; use
   `python3 scripts/render-dev-notes.py`.
 - Do not hand-edit generated project-documentation mirrors under

--- a/projects/openshell-agent-runner/RELEASING.md
+++ b/projects/openshell-agent-runner/RELEASING.md
@@ -1,7 +1,8 @@
 # Releasing openshell-agent-runner
 
-The release process publishes to PyPI from a local shell. A version tag supplies
-the package version, and `uv publish` uploads the built distributions.
+The release process publishes to PyPI from a local shell. An OAR-namespaced
+version tag (`oar-vX.Y.Z`) supplies the package version, and `uv publish` uploads
+the built distributions.
 
 Set a PyPI API token in the shell before publishing:
 
@@ -52,7 +53,7 @@ The script:
 1. Fetches `origin/main` and tags and confirms that local `main` is current.
 2. Runs the same checks and builds version `0.1.0` from the local tag.
 3. Checks the exact wheel and source distribution with `uv publish --dry-run`.
-4. Pushes `v0.1.0`, establishing the public source commit before publication.
+4. Pushes `oar-v0.1.0`, establishing the public source commit before publication.
 5. Uploads only those two artifacts to PyPI with `uv publish`.
 6. Prints the version-specific PyPI project link.
 

--- a/projects/openshell-agent-runner/pyproject.toml
+++ b/projects/openshell-agent-runner/pyproject.toml
@@ -51,6 +51,7 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
+pattern-prefix = "oar-"
 bump = true
 
 [tool.hatch.build.targets.wheel]

--- a/projects/openshell-agent-runner/scripts/publish.sh
+++ b/projects/openshell-agent-runner/scripts/publish.sh
@@ -86,7 +86,7 @@ if [[ "$CURRENT_BRANCH" != "main" && "$ALLOW_NON_MAIN" != true ]]; then
     exit 1
 fi
 
-TAG="v$VERSION"
+TAG="oar-v$VERSION"
 git fetch origin main --tags
 
 if [[ "$ALLOW_NON_MAIN" != true ]] && \

--- a/projects/openshell-agent-runner/tests/test_release.py
+++ b/projects/openshell-agent-runner/tests/test_release.py
@@ -36,7 +36,7 @@ def test_publish_prints_tag_deletion_commands_for_existing_remote_tag(
         if [[ "$1" == "rev-parse" ]]; then printf 'abc123\\n'; exit 0; fi
         if [[ "$1" == "rev-list" ]]; then printf 'abc123\\n'; exit 0; fi
         if [[ "$1" == "ls-remote" ]]; then
-            printf 'abc123\\trefs/tags/v0.1.0\\n'
+            printf 'abc123\\trefs/tags/oar-v0.1.0\\n'
             exit 0
         fi
         exit 91
@@ -54,9 +54,9 @@ def test_publish_prints_tag_deletion_commands_for_existing_remote_tag(
     )
 
     assert result.returncode == 1
-    assert "remote tag 'v0.1.0' already exists" in result.stderr
-    assert "git tag -d 'v0.1.0'" in result.stderr
-    assert "git push origin --delete 'v0.1.0'" in result.stderr
+    assert "remote tag 'oar-v0.1.0' already exists" in result.stderr
+    assert "git tag -d 'oar-v0.1.0'" in result.stderr
+    assert "git push origin --delete 'oar-v0.1.0'" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -94,7 +94,7 @@ def test_publish_retry_uploads_only_missing_artifacts(
         if [[ "$1" == "rev-list" ]]; then printf 'abc123\\n'; exit 0; fi
         if [[ "$1" == "ls-remote" ]]; then
             if [[ -e "$FAKE_GIT_STATE/remote-tag" ]]; then
-                printf 'abc123\\trefs/tags/v0.1.0\\n'
+                printf 'abc123\\trefs/tags/oar-v0.1.0\\n'
             fi
             exit 0
         fi


### PR DESCRIPTION
## Summary
- publish OAR releases with oar-vX.Y.Z tags
- restrict dynamic version discovery to OAR-prefixed tags
- document the repository-wide project tag namespace rule
- update release tests and guidance

## Validation
- make check (104 tests passed)
- make build
- isolated build from oar-v1.2.3 alongside unrelated-v9.9.9 produced version 1.2.3