### PR TITLE
fix: address nspect package findings

### DIFF
--- a/projects/reachy-mini-openshell/pyproject.toml
+++ b/projects/reachy-mini-openshell/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
  "gradio_client>=1.13.3",
  "setuptools>=84,<85", # 84.0.0 fixes setuptools security advisories pulled in by torch.
  "starlette>=1.6,<2", # 1.6.0 fixes Starlette security advisories pulled in by Gradio and reachy-mini.
+ "tornado>=6.5.8,<7", # 6.5.8 fixes Tornado advisories pulled in by reachy-mini.
 ]
 [[project.authors]]
 name = "Pollen Robotics"

--- a/projects/reachy-mini-openshell/uv.lock
+++ b/projects/reachy-mini-openshell/uv.lock
@@ -2044,6 +2044,7 @@ dependencies = [
     { name = "reachy-mini-toolbox", marker = "sys_platform == 'darwin'" },
     { name = "setuptools", marker = "sys_platform == 'darwin'" },
     { name = "starlette", marker = "sys_platform == 'darwin'" },
+    { name = "tornado", marker = "sys_platform == 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -2115,6 +2116,7 @@ requires-dist = [
     { name = "supervision", marker = "extra == 'yolo-vision'" },
     { name = "torch", marker = "extra == 'all-vision'", specifier = ">=2.13,<3" },
     { name = "torch", marker = "extra == 'local-vision'", specifier = ">=2.13,<3" },
+    { name = "tornado", specifier = ">=6.5.8,<7" },
     { name = "transformers", marker = "extra == 'all-vision'", specifier = ">=5.15.1,<6" },
     { name = "transformers", marker = "extra == 'local-vision'", specifier = ">=5.15.1,<6" },
     { name = "ultralytics", marker = "extra == 'all-vision'" },
@@ -2641,12 +2643,12 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.7"
+version = "6.5.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
 ]
 
 [[package]]

--- a/projects/robotics-policy-prover/package-lock.json
+++ b/projects/robotics-policy-prover/package-lock.json
@@ -1376,12 +1376,6 @@
         "three": ">=0.128.0"
       }
     },
-    "node_modules/three-stdlib/node_modules/fflate": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",

--- a/projects/robotics-policy-prover/package.json
+++ b/projects/robotics-policy-prover/package.json
@@ -22,5 +22,8 @@
     "@vitejs/plugin-react": "^6.0.2",
     "playwright": "^1.60.0",
     "vite": "^8.0.14"
+  },
+  "overrides": {
+    "fflate": "0.8.3"
   }
 }


### PR DESCRIPTION
## Summary

- override the vulnerable transitive fflate 0.6.10 with 0.8.3
- require Tornado 6.5.8 and refresh the Reachy lockfile
- retain GStreamer 1.28.6 because the recommended 1.29.2a0 bundle is not resolvable on supported macOS/Python environments: gstreamer-python 1.29.2a0 has no compatible macOS wheel

## Validation

- npm audit --omit=dev
- npm ls fflate --all
- npm run build
- npm run verify:visual
- uv lock --check
- frozen uv export confirms tornado==6.5.8
- Ruff manifest check
- git diff --check

## Environment limitations

- Reachy full lint, type, and pytest checks require the macOS-only locked environment and cannot run on this Linux host.
- Cargo tests were attempted but this host does not provide CMake; the changed robotics dependency is limited to the web application.