### PR TITLE
Improve documentation SEO metadata

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,8 @@ jobs:
         run: >-
           uv run --python ${{ matrix.python-version }} --with pytest==8.4.2
           pytest -q tests/test_agent_markdown.py tests/test_docs_404.py
-          tests/test_render_dev_notes.py tests/test_stage_project_docs.py
+          tests/test_docs_seo.py tests/test_render_dev_notes.py
+          tests/test_stage_project_docs.py
 
   validate:
     name: Validate documentation

--- a/docs/dev-notes/posts/2026-07-20-policy-controlling-reachy-mini-with-openshell.md
+++ b/docs/dev-notes/posts/2026-07-20-policy-controlling-reachy-mini-with-openshell.md
@@ -3,8 +3,10 @@ title: "Bringing Privacy and Security to the Edge with OpenShell"
 date: 2026-07-20
 updated: 2026-07-20
 description: "Edge agents handle sensitive data and make decisions with physical consequences. Reachy Mini shows why privacy and safety controls must be deterministic and local."
+author: "Kirit Thadaka"
 agent_markdown: true
 hero_image: "../../assets/reachy-mini-openshell/hero.svg"
+social_image: "assets/reachy-mini-openshell/hero.svg"
 categories:
   - Edge AI
 tags:

--- a/docs/dev-notes/posts/2026-08-07-formal-methods-ai-generated-robot-actions.md
+++ b/docs/dev-notes/posts/2026-08-07-formal-methods-ai-generated-robot-actions.md
@@ -3,8 +3,10 @@ title: "Can Formal Methods Govern AI-Generated Robot Actions?"
 date: 2026-08-07
 updated: 2026-08-10
 description: "A robotics experiment asks whether an independent, SMT-backed policy boundary can efficiently govern AI-generated plans before they reach a simulated or physical robot."
+author: "Alex Watson"
 agent_markdown: true
 hero_image: "../../assets/robotics-policy-prover/robotics-policy-prover-hero.png"
+social_image: "assets/robotics-policy-prover/robotics-policy-prover-hero.png"
 categories:
   - Physical AI
 tags:

--- a/docs/dev-notes/posts/2026-08-27-adversarial-policy-review-long-horizon-agents.md
+++ b/docs/dev-notes/posts/2026-08-27-adversarial-policy-review-long-horizon-agents.md
@@ -2,8 +2,10 @@
 title: "Adversarial prototype: AI policy auto-approval for long-horizon agents in OpenShell"
 date: 2026-08-27
 description: "Can an attacker agent convince an equally capable reviewer agent to grant a capability that is explicitly prohibited?"
+author: "Alex Watson"
 agent_markdown: true
 hero_image: "../../assets/long-horizon-agent-evals/back-and-forth-by-session.png"
+social_image: "assets/long-horizon-agent-evals/back-and-forth-by-session.png"
 categories:
   - OpenShell
 tags:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenShell Research
-description: Dev Notes and software documentation from the OpenShell team.
+description: OpenShell research, experiments, and documentation for secure AI agents, policy enforcement, automation, and robotics.
 hide:
   - toc
 ---

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,6 +3,7 @@
 
 {% block extrahead %}
   {{ super() }}
+  {% include "partials/seo.html" %}
   <script>
     try {
       document.documentElement.dataset.navigationDrawer =
@@ -15,5 +16,13 @@
   </script>
   {% if page.meta and page.meta.agent_markdown %}
     <link rel="alternate" type="text/markdown" href="{{ agent_markdown.href(page) }}" title="Markdown source">
+  {% endif %}
+{% endblock %}
+
+{% block htmltitle %}
+  {% if page.canonical_url == config.site_url %}
+    <title>{{ config.site_name }}</title>
+  {% else %}
+    {{ super() }}
   {% endif %}
 {% endblock %}

--- a/overrides/partials/seo.html
+++ b/overrides/partials/seo.html
@@ -1,0 +1,59 @@
+{% set seo = namespace() %}
+{% set seo.noindex = false %}
+{% if page.canonical_url %}
+  {% for prefix in config.extra.seo.noindex_prefixes %}
+    {% set prefix_url = config.site_url ~ prefix %}
+    {% if prefix_url in page.canonical_url %}
+      {% set seo.noindex = true %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% set robots = "noindex, follow" if seo.noindex else (page.meta.robots if page.meta and page.meta.robots else "") %}
+{% if robots %}
+  <meta name="robots" content="{{ robots }}">
+{% endif %}
+{% if page.canonical_url and "noindex" not in robots %}
+  {% set title = page.meta.title if page.meta and page.meta.title else page.title %}
+  {% set description = page.meta.description if page.meta and page.meta.description else config.site_description %}
+  {% set social_image = page.meta.social_image if page.meta and page.meta.social_image else "" %}
+  <meta property="og:type" content="{{ 'article' if page.meta and page.meta.date else 'website' }}">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta name="twitter:card" content="{{ 'summary_large_image' if social_image else 'summary' }}">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description }}">
+  {% if social_image %}
+    {% set social_image_url = config.site_url ~ social_image %}
+    <meta property="og:image" content="{{ social_image_url }}">
+    <meta property="og:image:alt" content="{{ title }}">
+    <meta name="twitter:image" content="{{ social_image_url }}">
+    <meta name="twitter:image:alt" content="{{ title }}">
+  {% endif %}
+  {% if page.meta and page.meta.date %}
+    <meta property="article:published_time" content="{{ page.meta.date }}">
+    <meta property="article:modified_time" content="{{ page.meta.updated or page.meta.date }}">
+  {% endif %}
+  {% if page.meta and page.meta.date and page.meta.author and social_image %}
+    <script type="application/ld+json">
+      {{- {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "author": {
+          "@type": "Person",
+          "name": page.meta.author
+        },
+        "dateModified": page.meta.updated or page.meta.date,
+        "datePublished": page.meta.date,
+        "description": description,
+        "headline": title,
+        "image": social_image_url,
+        "mainEntityOfPage": {
+          "@id": page.canonical_url,
+          "@type": "WebPage"
+        }
+      } | tojson -}}
+    </script>
+  {% endif %}
+{% endif %}

--- a/overrides/sitemap.xml
+++ b/overrides/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      {# The homepage is intentionally outside the explicit navigation. #}
+      <url>
+        <loc>{{ config.site_url }}</loc>
+      </url>
+  {%- for page in pages -%}
+    {%- set seo = namespace() -%}
+    {%- set seo.noindex = false -%}
+    {%- if page.canonical_url -%}
+      {%- for prefix in config.extra.seo.noindex_prefixes -%}
+        {%- set prefix_url = config.site_url ~ prefix -%}
+        {%- if prefix_url in page.canonical_url -%}
+          {%- set seo.noindex = true -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {%- if page.canonical_url and not seo.noindex %}
+      <url>
+        <loc>{{ page.canonical_url }}</loc>
+      </url>
+    {%- endif -%}
+  {%- endfor %}
+</urlset>

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,2 @@
+pytest==8.4.2
 zensical==0.0.44

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -38,3 +38,4 @@ REQUIRE_RENDERED_AGENT_MARKDOWN=1 python tests/test_agent_markdown.py
 REQUIRE_RENDERED_404=1 python tests/test_docs_404.py
 REQUIRE_RENDERED_NAVIGATION=1 python tests/test_navigation_drawer.py
 REQUIRE_RENDERED_PAGE_NAVIGATION=1 python tests/test_page_navigation.py
+REQUIRE_RENDERED_SEO=1 python -m pytest -q tests/test_docs_seo.py

--- a/tests/test_docs_seo.py
+++ b/tests/test_docs_seo.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+import json
+import os
+from pathlib import Path
+import xml.etree.ElementTree as ElementTree
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+SITE = ROOT / "site"
+CONFIG = ROOT / "zensical.toml"
+SITE_URL = "https://nvidia.github.io/OpenShell-Research/"
+PUBLIC_SOURCE_ROOTS = (DOCS / "dev-notes", DOCS / "documentation")
+NOINDEX_SOURCE_ROOTS = (DOCS / "development", DOCS / "projects", DOCS / "research")
+REQUIRE_RENDERED = os.environ.get("REQUIRE_RENDERED_SEO") == "1"
+
+
+class HeadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_head = False
+        self.in_title = False
+        self.in_structured_data = False
+        self.links: list[dict[str, str | None]] = []
+        self.meta: list[dict[str, str | None]] = []
+        self.structured_data: list[str] = []
+        self.title_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if tag == "head":
+            self.in_head = True
+        elif self.in_head and tag == "title":
+            self.in_title = True
+        elif self.in_head and tag == "link":
+            self.links.append(attributes)
+        elif self.in_head and tag == "meta":
+            self.meta.append(attributes)
+        elif (
+            self.in_head
+            and tag == "script"
+            and attributes.get("type") == "application/ld+json"
+        ):
+            self.in_structured_data = True
+            self.structured_data.append("")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "head":
+            self.in_head = False
+        elif tag == "title":
+            self.in_title = False
+        elif tag == "script":
+            self.in_structured_data = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title:
+            self.title_parts.append(data)
+        elif self.in_structured_data:
+            self.structured_data[-1] += data
+
+    @property
+    def title(self) -> str:
+        return "".join(self.title_parts).strip()
+
+    def meta_content(self, attribute: str, value: str) -> list[str]:
+        return [
+            item.get("content") or ""
+            for item in self.meta
+            if item.get(attribute) == value
+        ]
+
+    def link_hrefs(self, relation: str) -> list[str]:
+        return [
+            item.get("href") or ""
+            for item in self.links
+            if relation in (item.get("rel") or "").split()
+        ]
+
+
+def public_sources() -> list[Path]:
+    sources = [DOCS / "index.md"]
+    for source_root in PUBLIC_SOURCE_ROOTS:
+        sources.extend(source_root.rglob("*.md"))
+    return sorted(sources)
+
+
+def noindex_sources() -> list[Path]:
+    sources: list[Path] = []
+    for source_root in NOINDEX_SOURCE_ROOTS:
+        sources.extend(source_root.rglob("*.md"))
+    return sorted(sources)
+
+
+def canonical_url(source: Path) -> str:
+    relative = source.relative_to(DOCS)
+    if relative == Path("index.md"):
+        return SITE_URL
+    if relative.name == "index.md":
+        return f"{SITE_URL}{relative.parent.as_posix()}/"
+    return f"{SITE_URL}{relative.with_suffix('').as_posix()}/"
+
+
+def rendered_page(source: Path) -> Path:
+    relative = source.relative_to(DOCS)
+    if relative.name == "index.md":
+        return SITE / relative.parent / "index.html"
+    return SITE / relative.with_suffix("") / "index.html"
+
+
+def parse_head(source: Path) -> HeadParser:
+    parser = HeadParser()
+    parser.feed(rendered_page(source).read_text(encoding="utf-8"))
+    return parser
+
+
+def test_production_site_url_is_configured() -> None:
+    config = CONFIG.read_text(encoding="utf-8")
+
+    assert f'site_url = "{SITE_URL}"' in config
+
+
+def test_non_public_source_roots_opt_out_of_indexing() -> None:
+    config = CONFIG.read_text(encoding="utf-8")
+
+    assert 'noindex_prefixes = ["development/", "projects/", "research/"]' in config
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_sitemap_contains_only_public_canonical_urls() -> None:
+    sitemap = ElementTree.parse(SITE / "sitemap.xml")
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    actual_locations = [
+        location.text
+        for location in sitemap.findall("sitemap:url/sitemap:loc", namespace)
+    ]
+    actual = set(actual_locations)
+    expected = {canonical_url(source) for source in public_sources()}
+
+    assert len(actual_locations) == len(actual)
+    assert actual == expected
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_public_pages_have_canonical_and_social_metadata() -> None:
+    for source in public_sources():
+        parser = parse_head(source)
+        expected_url = canonical_url(source)
+
+        assert parser.link_hrefs("canonical") == [expected_url]
+        assert parser.meta_content("name", "robots") == []
+        assert parser.meta_content("property", "og:url") == [expected_url]
+        assert len(parser.meta_content("property", "og:title")) == 1
+        assert len(parser.meta_content("property", "og:description")) == 1
+        assert len(parser.meta_content("name", "twitter:card")) == 1
+        assert len(parser.meta_content("name", "twitter:title")) == 1
+        assert len(parser.meta_content("name", "twitter:description")) == 1
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_non_public_pages_are_noindex_and_absent_from_social_metadata() -> None:
+    for source in noindex_sources():
+        parser = parse_head(source)
+
+        assert parser.meta_content("name", "robots") == ["noindex, follow"]
+        assert parser.meta_content("property", "og:url") == []
+        assert parser.meta_content("name", "twitter:card") == []
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_homepage_title_is_not_duplicated() -> None:
+    parser = parse_head(DOCS / "index.md")
+
+    assert parser.title == "OpenShell Research"
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_dev_notes_have_valid_tech_article_metadata() -> None:
+    posts = sorted((DOCS / "dev-notes" / "posts").glob("*.md"))
+
+    assert posts
+    for post in posts:
+        parser = parse_head(post)
+        assert len(parser.structured_data) == 1
+        article = json.loads(parser.structured_data[0])
+
+        assert article["@context"] == "https://schema.org"
+        assert article["@type"] == "TechArticle"
+        assert article["mainEntityOfPage"]["@id"] == canonical_url(post)
+        assert article["image"].startswith(SITE_URL)
+        assert (SITE / article["image"].removeprefix(SITE_URL)).is_file()
+        assert parser.meta_content("property", "og:image") == [article["image"]]
+        assert parser.meta_content("property", "article:published_time") == [
+            article["datePublished"]
+        ]
+        assert article["author"]["name"]
+        assert article["datePublished"]
+        assert article["headline"]
+
+
+@pytest.mark.skipif(not REQUIRE_RENDERED, reason="rendered SEO is checked after build")
+def test_seo_metadata_is_confined_to_the_document_head() -> None:
+    for source in public_sources() + noindex_sources():
+        html = rendered_page(source).read_text(encoding="utf-8")
+        body = html.split("<body", maxsplit=1)[1]
+
+        assert 'property="og:' not in body
+        assert 'name="twitter:' not in body
+        assert 'name="robots"' not in body
+        assert 'application/ld+json' not in body

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,7 @@
 [project]
 site_name = "OpenShell Research"
-site_description = "Research engineering Dev Notes and software documentation from the OpenShell team."
+site_url = "https://nvidia.github.io/OpenShell-Research/"
+site_description = "Research engineering Dev Notes and documentation for secure AI agents, policy enforcement, automation, and robotics with OpenShell."
 site_author = "OpenShell Research Engineering"
 repo_url = "https://github.com/NVIDIA/OpenShell-Research"
 repo_name = "OpenShell Research on GitHub"
@@ -58,6 +59,10 @@ nav = [
 [project.extra]
 homepage = "."
 generator = false
+
+[project.extra.seo]
+# Keep internal instructions and legacy entry points available without indexing them.
+noindex_prefixes = ["development/", "projects/", "research/"]
 
 [project.markdown_extensions.admonition]
 


### PR DESCRIPTION
## Summary

- configure the production site URL so Zensical emits canonical links
- publish a filtered sitemap containing only the 19 public documentation pages
- mark internal and legacy documentation paths as noindex while keeping them reachable
- add Open Graph, Twitter Card, and TechArticle metadata
- remove the duplicated homepage title and improve search-result descriptions
- add rendered SEO regression coverage to the documentation workflow

## UX preservation

The rendered body of all 29 HTML pages is byte-for-byte identical to main. Layout, navigation, content, styling, and site-search behavior are unchanged.

## Validation

- documentation unit tests: 25 passed, 9 skipped rendered-only checks
- rendered SEO tests: 8 passed
- scripts/build-docs.sh
- strict Zensical build
- local artifact preview returned HTTP 200