### PR TITLE
Add PyPI release process for middleware manager

### DIFF
--- a/projects/openshell-middleware-manager/LICENSE
+++ b/projects/openshell-middleware-manager/LICENSE
@@ -1,0 +1,203 @@
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/projects/openshell-middleware-manager/Makefile
+++ b/projects/openshell-middleware-manager/Makefile
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+.DEFAULT_GOAL := help
+
+UV ?= uv
+UV_RUN := $(UV) run --frozen
+PYTEST_ARGS ?=
+
+PUBLISH_FLAGS :=
+ifdef DRY_RUN
+PUBLISH_FLAGS += --dry-run
+endif
+ifdef ALLOW_NON_MAIN
+PUBLISH_FLAGS += --allow-non-main
+endif
+ifdef RETRY_ARTIFACT
+PUBLISH_FLAGS += --retry-artifact $(RETRY_ARTIFACT)
+endif
+
+.PHONY: help sync test format-check lint typecheck check build clean publish
+
+help: ## Show available targets and configurable variables.
+	@printf "\033[1;36mOpenShell Middleware Manager\033[0m\n"
+	@printf "\033[2mUsage: make <target> [VARIABLE=value]\033[0m\n"
+	@printf "\n\033[1;33m🛠  Development\033[0m\n"
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_.-]+:.*## / && $$1 != "publish" {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@printf "\n\033[1;33m📦 Release\033[0m\n"
+	@awk 'BEGIN {FS = ":.*## "}; $$1 == "publish" {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@printf "\n\033[1;33m⚙  Configuration\033[0m\n"
+	@printf "  \033[32m%-20s\033[0m %s\n" "PYTEST_ARGS=..." "Extra pytest paths or flags"
+	@printf "  \033[32m%-20s\033[0m %s\n" "VERSION=X.Y.Z" "Required package version for publish"
+	@printf "  \033[32m%-20s\033[0m %s\n" "DRY_RUN=1" "Validate a release without tagging or uploading"
+	@printf "  \033[32m%-20s\033[0m %s\n" "ALLOW_NON_MAIN=1" "Permit release validation or publishing off main"
+	@printf "  \033[32m%-20s\033[0m %s\n" "RETRY_ARTIFACT=..." "Retry a missing wheel, sdist, or both after a failed upload"
+
+sync: ## Install locked runtime and development dependencies.
+	$(UV) sync --locked
+
+test: ## Run tests; pass paths or flags with PYTEST_ARGS.
+	$(UV_RUN) pytest $(PYTEST_ARGS)
+
+format-check: ## Check Python formatting.
+	$(UV_RUN) ruff format --check .
+
+lint: ## Run Ruff lint checks.
+	$(UV_RUN) ruff check .
+
+typecheck: ## Run ty type checks.
+	$(UV_RUN) ty check
+
+check: sync format-check lint typecheck test ## Run the full project checks.
+	$(UV_RUN) python -m compileall -q src tests
+
+build: ## Build the source distribution and wheel.
+	$(UV) build --clear --no-sources
+
+clean: ## Remove build, test, lint, and Python cache artifacts.
+	rm -rf build dist .pytest_cache .ruff_cache .coverage
+	find src tests -type d -name __pycache__ -prune -exec rm -rf {} +
+
+publish: ## Validate or publish a release; requires VERSION.
+ifndef VERSION
+	$(error VERSION is required, e.g. make publish VERSION=0.1.0 DRY_RUN=1)
+endif
+	./scripts/publish.sh $(VERSION) $(PUBLISH_FLAGS)

--- a/projects/openshell-middleware-manager/README.md
+++ b/projects/openshell-middleware-manager/README.md
@@ -87,8 +87,9 @@ The starter templates still use the older `max_body_bytes` binding field, so
 that starter. `omm update` can refresh an existing service already compatible
 with the newer contract, such as Egress Gate.
 
-Run `omm --help` for all options. By default, `omm` derives the Python package
-name from the project name. Use `--package-name` to set it yourself.
+Run `omm --help` for all options and `omm --version` for the installed OMM
+version. By default, `omm` derives the Python package name from the project
+name. Use `--package-name` to set it yourself.
 
 ## Update a project
 

--- a/projects/openshell-middleware-manager/README.md
+++ b/projects/openshell-middleware-manager/README.md
@@ -16,7 +16,19 @@ The CLI does not install or change OpenShell.
 
 ## Install the CLI
 
-Install `omm` from GitHub with `uv`:
+Run `omm` without installing it permanently:
+
+```sh
+uvx --from openshell-middleware-manager omm --help
+```
+
+Or install `omm` from PyPI with `uv`:
+
+```sh
+uv tool install openshell-middleware-manager
+```
+
+To install the current development version from GitHub instead:
 
 ```sh
 uv tool install \
@@ -178,3 +190,6 @@ uv build
 
 Unit tests use local protocol fixtures. They do not contact GitHub or run `uv`
 or Cargo inside generated projects.
+
+See [RELEASING.md](https://github.com/NVIDIA/OpenShell-Research/blob/main/projects/openshell-middleware-manager/RELEASING.md)
+for the local PyPI release process.

--- a/projects/openshell-middleware-manager/RELEASING.md
+++ b/projects/openshell-middleware-manager/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing openshell-middleware-manager
+
+The release process publishes to PyPI from a local shell. An OMM-namespaced
+version tag (`omm-vX.Y.Z`) supplies the package version, and `uv publish` uploads
+the built distributions.
+
+Set a PyPI API token in the shell before publishing:
+
+```bash
+export UV_PUBLISH_TOKEN="pypi-..."
+```
+
+The script reads the token from the environment and never prints it. It does not
+use `.pypirc`. If the export is in `~/.bashrc`, open an interactive shell or
+source that file before running `make publish`.
+
+## Validate a release
+
+From this directory, run:
+
+```bash
+make publish VERSION=0.1.0 DRY_RUN=1
+```
+
+The dry run fetches `origin/main` and tags, confirms that local `main` is current,
+runs the project validation suite, and builds the requested version. It checks
+one wheel and one source distribution with `uv publish --dry-run`. Trusted
+publishing is disabled because this workflow is intentionally local. The
+temporary local tag is removed before the command exits; nothing is pushed or
+uploaded.
+
+To validate or publish deliberately from another branch, add
+`ALLOW_NON_MAIN=1`:
+
+```bash
+make publish VERSION=0.1.0 DRY_RUN=1 ALLOW_NON_MAIN=1
+```
+
+This bypasses the branch and `origin/main` commit checks. The working tree must
+still be clean, an existing version tag must point to the current commit, and
+every release check must pass.
+
+## Publish a release
+
+After the release commit is merged and checked out on a clean `main` branch:
+
+```bash
+make publish VERSION=0.1.0
+```
+
+The script:
+
+1. Fetches `origin/main` and tags and confirms that local `main` is current.
+2. Runs the same checks and builds version `0.1.0` from the local tag.
+3. Checks the exact wheel and source distribution with `uv publish --dry-run`.
+4. Pushes `omm-v0.1.0`, establishing the public source commit before publication.
+5. Uploads only those two artifacts to PyPI with `uv publish`.
+6. Prints the version-specific PyPI project link.
+
+If the upload fails after the tag is pushed, check the `uv publish` output or
+PyPI to identify which artifacts are missing. Retry a missing artifact with:
+
+```bash
+make publish VERSION=0.1.0 RETRY_ARTIFACT=sdist
+```
+
+Use `wheel` instead of `sdist` when the wheel is missing. If neither artifact
+was accepted, use `RETRY_ARTIFACT=both`. Every retry rebuilds and checks both
+artifacts from the tagged commit, then uploads only the selected file or files.
+This works with private indexes that reject duplicate filenames. A retry
+requires the remote tag to match the current commit. If both files are already
+present, there is nothing to retry.

--- a/projects/openshell-middleware-manager/pyproject.toml
+++ b/projects/openshell-middleware-manager/pyproject.toml
@@ -5,6 +5,7 @@ description = "Create and update version-matched OpenShell middleware projects."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     { name = "NVIDIA CORPORATION & AFFILIATES" },
 ]
@@ -46,6 +47,7 @@ packages = ["src/openshell_middleware_manager"]
 [tool.hatch.build.targets.sdist]
 include = [
     "/src/openshell_middleware_manager",
+    "/LICENSE",
     "/README.md",
     "/pyproject.toml",
 ]

--- a/projects/openshell-middleware-manager/pyproject.toml
+++ b/projects/openshell-middleware-manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openshell-middleware-manager"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Create and update version-matched OpenShell middleware projects."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,8 +27,28 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.8,<0.12.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+pattern-prefix = "omm-"
+bump = true
+fallback-version = "0.1.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/openshell_middleware_manager"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/openshell_middleware_manager",
+    "/README.md",
+    "/pyproject.toml",
+]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/projects/openshell-middleware-manager/scripts/publish.sh
+++ b/projects/openshell-middleware-manager/scripts/publish.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+PROJECT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PYPI_PROJECT_URL="https://pypi.org/project/openshell-middleware-manager"
+
+usage() {
+    echo "Usage: $0 VERSION [--dry-run] [--allow-non-main] [--retry-artifact wheel|sdist|both]"
+    echo
+    echo "Build and publish openshell-middleware-manager to PyPI with uv."
+    echo "Publishing requires UV_PUBLISH_TOKEN in the current environment."
+}
+
+print_tag_deletion_instructions() {
+    echo "To delete the tag locally and from origin, run:" >&2
+    echo "  git tag -d '$TAG'" >&2
+    echo "  git push origin --delete '$TAG'" >&2
+}
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+VERSION="$1"
+DRY_RUN=false
+ALLOW_NON_MAIN=false
+RETRY_ARTIFACT=""
+shift
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --allow-non-main)
+            ALLOW_NON_MAIN=true
+            ;;
+        --retry-artifact)
+            if [[ $# -lt 2 ]]; then
+                usage >&2
+                exit 2
+            fi
+            RETRY_ARTIFACT="$2"
+            shift
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+    echo "publish: invalid version '$VERSION'; expected X.Y.Z or X.Y.ZrcN" >&2
+    exit 2
+fi
+if [[ -n "$RETRY_ARTIFACT" && "$RETRY_ARTIFACT" != "wheel" && "$RETRY_ARTIFACT" != "sdist" && "$RETRY_ARTIFACT" != "both" ]]; then
+    echo "publish: --retry-artifact must be 'wheel', 'sdist', or 'both'" >&2
+    exit 2
+fi
+if [[ "$DRY_RUN" == true && -n "$RETRY_ARTIFACT" ]]; then
+    echo "publish: --retry-artifact cannot be combined with --dry-run" >&2
+    exit 2
+fi
+
+cd "$PROJECT_DIRECTORY"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "publish: the working tree must be clean" >&2
+    exit 1
+fi
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" && "$ALLOW_NON_MAIN" != true ]]; then
+    echo "publish: releases must be created from main; pass --allow-non-main to override" >&2
+    exit 1
+fi
+
+TAG="omm-v$VERSION"
+git fetch origin main --tags
+
+if [[ "$ALLOW_NON_MAIN" != true ]] && \
+    [[ "$(git rev-parse HEAD)" != "$(git rev-parse refs/remotes/origin/main)" ]]; then
+    echo "publish: local main must match origin/main" >&2
+    exit 1
+fi
+
+TAG_CREATED=false
+TAG_PUBLIC=false
+if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+    if [[ "$(git rev-list -n 1 "$TAG")" != "$(git rev-parse HEAD)" ]]; then
+        echo "publish: tag '$TAG' exists on another commit" >&2
+        print_tag_deletion_instructions
+        exit 1
+    fi
+else
+    git tag "$TAG"
+    TAG_CREATED=true
+fi
+
+cleanup_local_tag() {
+    if [[ "$TAG_CREATED" == true && "$TAG_PUBLIC" != true ]]; then
+        git tag -d "$TAG" >/dev/null
+    fi
+}
+trap cleanup_local_tag EXIT
+
+REMOTE_TAG=$(git ls-remote --tags origin "refs/tags/$TAG" | cut -f1)
+if [[ -n "$REMOTE_TAG" ]]; then
+    if [[ "$REMOTE_TAG" != "$(git rev-parse HEAD)" ]]; then
+        echo "publish: remote tag '$TAG' exists on another commit" >&2
+        exit 1
+    fi
+    TAG_PUBLIC=true
+fi
+
+if [[ -n "$RETRY_ARTIFACT" && "$TAG_PUBLIC" != true ]]; then
+    echo "publish: --retry-artifact requires the matching remote tag '$TAG'" >&2
+    exit 1
+fi
+if [[ -z "$RETRY_ARTIFACT" && "$DRY_RUN" != true && "$TAG_PUBLIC" == true ]]; then
+    echo "publish: remote tag '$TAG' already exists; retry the missing artifact or artifacts with --retry-artifact" >&2
+    print_tag_deletion_instructions
+    exit 1
+fi
+
+echo "Running release checks..."
+make check
+
+echo "Building distributions..."
+make build
+
+shopt -s nullglob
+WHEELS=(dist/openshell_middleware_manager-"$VERSION"-*.whl)
+SDISTS=(dist/openshell_middleware_manager-"$VERSION".tar.gz)
+if [[ ${#WHEELS[@]} -ne 1 || ${#SDISTS[@]} -ne 1 ]]; then
+    echo "publish: expected one wheel and one source distribution for '$VERSION'" >&2
+    exit 1
+fi
+ARTIFACTS=("${WHEELS[@]}" "${SDISTS[@]}")
+uv publish --dry-run --trusted-publishing never "${ARTIFACTS[@]}"
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "Dry run complete; no tag was created and nothing was uploaded."
+    exit 0
+fi
+
+if [[ -z "${UV_PUBLISH_TOKEN:-}" ]]; then
+    echo "publish: UV_PUBLISH_TOKEN is not set; export it before publishing" >&2
+    exit 1
+fi
+
+if [[ "$TAG_PUBLIC" != true ]]; then
+    git push origin "$TAG"
+    TAG_PUBLIC=true
+fi
+
+UPLOAD_ARTIFACTS=("${ARTIFACTS[@]}")
+if [[ "$RETRY_ARTIFACT" == "wheel" ]]; then
+    UPLOAD_ARTIFACTS=("${WHEELS[@]}")
+elif [[ "$RETRY_ARTIFACT" == "sdist" ]]; then
+    UPLOAD_ARTIFACTS=("${SDISTS[@]}")
+fi
+
+echo "Uploading openshell-middleware-manager $VERSION to PyPI with uv..."
+if ! uv publish --trusted-publishing never "${UPLOAD_ARTIFACTS[@]}"; then
+    echo "publish: upload failed; identify the missing artifact or artifacts before retrying" >&2
+    exit 1
+fi
+
+if [[ "$RETRY_ARTIFACT" == "wheel" || "$RETRY_ARTIFACT" == "sdist" ]]; then
+    echo "Uploaded the missing $RETRY_ARTIFACT artifact for openshell-middleware-manager $VERSION."
+else
+    echo "Published openshell-middleware-manager $VERSION from $TAG."
+fi
+echo "PyPI: $PYPI_PROJECT_URL/$VERSION/"

--- a/projects/openshell-middleware-manager/scripts/publish.sh
+++ b/projects/openshell-middleware-manager/scripts/publish.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+PUBLISH_TOKEN="${UV_PUBLISH_TOKEN:-}"
+unset UV_PUBLISH_TOKEN
+
 PROJECT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 PYPI_PROJECT_URL="https://pypi.org/project/openshell-middleware-manager"
 
@@ -12,12 +15,6 @@ usage() {
     echo
     echo "Build and publish openshell-middleware-manager to PyPI with uv."
     echo "Publishing requires UV_PUBLISH_TOKEN in the current environment."
-}
-
-print_tag_deletion_instructions() {
-    echo "To delete the tag locally and from origin, run:" >&2
-    echo "  git tag -d '$TAG'" >&2
-    echo "  git push origin --delete '$TAG'" >&2
 }
 
 if [[ $# -lt 1 ]]; then
@@ -100,7 +97,6 @@ TAG_PUBLIC=false
 if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
     if [[ "$(git rev-list -n 1 "$TAG")" != "$(git rev-parse HEAD)" ]]; then
         echo "publish: tag '$TAG' exists on another commit" >&2
-        print_tag_deletion_instructions
         exit 1
     fi
 else
@@ -130,7 +126,6 @@ if [[ -n "$RETRY_ARTIFACT" && "$TAG_PUBLIC" != true ]]; then
 fi
 if [[ -z "$RETRY_ARTIFACT" && "$DRY_RUN" != true && "$TAG_PUBLIC" == true ]]; then
     echo "publish: remote tag '$TAG' already exists; retry the missing artifact or artifacts with --retry-artifact" >&2
-    print_tag_deletion_instructions
     exit 1
 fi
 
@@ -155,7 +150,7 @@ if [[ "$DRY_RUN" == true ]]; then
     exit 0
 fi
 
-if [[ -z "${UV_PUBLISH_TOKEN:-}" ]]; then
+if [[ -z "$PUBLISH_TOKEN" ]]; then
     echo "publish: UV_PUBLISH_TOKEN is not set; export it before publishing" >&2
     exit 1
 fi
@@ -173,7 +168,7 @@ elif [[ "$RETRY_ARTIFACT" == "sdist" ]]; then
 fi
 
 echo "Uploading openshell-middleware-manager $VERSION to PyPI with uv..."
-if ! uv publish --trusted-publishing never "${UPLOAD_ARTIFACTS[@]}"; then
+if ! UV_PUBLISH_TOKEN="$PUBLISH_TOKEN" uv publish --trusted-publishing never "${UPLOAD_ARTIFACTS[@]}"; then
     echo "publish: upload failed; identify the missing artifact or artifacts before retrying" >&2
     exit 1
 fi

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/__init__.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/__init__.py
@@ -3,4 +3,6 @@
 
 """Create and update version-matched OpenShell middleware projects."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("openshell-middleware-manager")

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 import shlex
 from enum import Enum
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as distribution_version
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
+from openshell_middleware_manager import __version__
 from openshell_middleware_manager.generator import (
     ProjectError,
     create_project,
@@ -24,7 +23,7 @@ from openshell_middleware_manager.generator import (
 def version_callback(value: bool) -> None:
     """Print the installed OMM version when requested."""
     if value:
-        typer.echo(f"omm {_installed_version()}")
+        typer.echo(f"omm {__version__}")
         raise typer.Exit()
 
 
@@ -155,13 +154,6 @@ def update(
 def _report_error(error: ProjectError) -> None:
     typer.echo(f"omm: error: {error}", err=True)
     raise typer.Exit(code=1) from error
-
-
-def _installed_version() -> str:
-    try:
-        return distribution_version("openshell-middleware-manager")
-    except PackageNotFoundError:
-        return "unknown"
 
 
 def main() -> None:

--- a/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
+++ b/projects/openshell-middleware-manager/src/openshell_middleware_manager/cli.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import shlex
 from enum import Enum
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 from typing import Annotated
 
@@ -17,6 +19,13 @@ from openshell_middleware_manager.generator import (
     create_project,
     update_project,
 )
+
+
+def version_callback(value: bool) -> None:
+    """Print the installed OMM version when requested."""
+    if value:
+        typer.echo(f"omm {_installed_version()}")
+        raise typer.Exit()
 
 
 class Language(str, Enum):
@@ -32,6 +41,21 @@ app = typer.Typer(
     pretty_exceptions_enable=False,
     help="Create or update a version-matched OpenShell middleware project.",
 )
+
+
+@app.callback()
+def root(
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=version_callback,
+            is_eager=True,
+            help="Show the installed OMM version and exit.",
+        ),
+    ] = None,
+) -> None:
+    """Create or update a version-matched OpenShell middleware project."""
 
 
 @app.command()
@@ -131,6 +155,13 @@ def update(
 def _report_error(error: ProjectError) -> None:
     typer.echo(f"omm: error: {error}", err=True)
     raise typer.Exit(code=1) from error
+
+
+def _installed_version() -> str:
+    try:
+        return distribution_version("openshell-middleware-manager")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def main() -> None:

--- a/projects/openshell-middleware-manager/tests/test_cli.py
+++ b/projects/openshell-middleware-manager/tests/test_cli.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 from pathlib import Path
 
@@ -34,20 +33,6 @@ def test_version_reports_installed_distribution_version() -> None:
 
     assert result.exit_code == 0
     assert result.stdout == f"omm {distribution_version('openshell-middleware-manager')}\n"
-
-
-def test_version_handles_unavailable_distribution_metadata(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def missing_distribution(_distribution_name: str) -> str:
-        raise PackageNotFoundError
-
-    monkeypatch.setattr(cli, "distribution_version", missing_distribution)
-
-    result = runner.invoke(cli.app, ["--version"])
-
-    assert result.exit_code == 0
-    assert result.stdout == "omm unknown\n"
 
 
 def test_cli_reports_success(monkeypatch, tmp_path: Path) -> None:

--- a/projects/openshell-middleware-manager/tests/test_cli.py
+++ b/projects/openshell-middleware-manager/tests/test_cli.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 
 import pytest
@@ -18,12 +20,34 @@ def test_help_describes_required_choices() -> None:
     assert result.exit_code == 0
     assert "create" in result.stdout
     assert "update" in result.stdout
+    assert "--version" in result.stdout
 
     create_help = runner.invoke(cli.app, ["create", "--help"])
 
     assert create_help.exit_code == 0
     assert "--language" in create_help.stdout
     assert "--openshell-version" in create_help.stdout
+
+
+def test_version_reports_installed_distribution_version() -> None:
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == f"omm {distribution_version('openshell-middleware-manager')}\n"
+
+
+def test_version_handles_unavailable_distribution_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_distribution(_distribution_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(cli, "distribution_version", missing_distribution)
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "omm unknown\n"
 
 
 def test_cli_reports_success(monkeypatch, tmp_path: Path) -> None:

--- a/projects/openshell-middleware-manager/tests/test_release.py
+++ b/projects/openshell-middleware-manager/tests/test_release.py
@@ -14,7 +14,7 @@ PUBLISH_SCRIPT = REPOSITORY / "projects/openshell-middleware-manager/scripts/pub
 PROJECT_MAKEFILE = REPOSITORY / "projects/openshell-middleware-manager/Makefile"
 
 
-def test_publish_prints_tag_deletion_commands_for_existing_remote_tag(
+def test_publish_existing_remote_tag_requests_artifact_retry(
     tmp_path: Path,
 ) -> None:
     project = tmp_path / "project"
@@ -55,8 +55,8 @@ def test_publish_prints_tag_deletion_commands_for_existing_remote_tag(
 
     assert result.returncode == 1
     assert "remote tag 'omm-v0.1.0' already exists" in result.stderr
-    assert "git tag -d 'omm-v0.1.0'" in result.stderr
-    assert "git push origin --delete 'omm-v0.1.0'" in result.stderr
+    assert "--retry-artifact" in result.stderr
+    assert "git tag -d" not in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -112,7 +112,7 @@ def test_publish_retry_uploads_only_missing_artifacts(
         fake_bin / "uv",
         """
         #!/usr/bin/env bash
-        printf '%s\\n' "$*" >> "$FAKE_UV_LOG"
+        printf '%s|token=%s\\n' "$*" "${UV_PUBLISH_TOKEN:-}" >> "$FAKE_UV_LOG"
         if [[ "$1" == "build" ]]; then
             mkdir -p dist
             : > dist/openshell_middleware_manager-0.1.0-py3-none-any.whl
@@ -175,11 +175,16 @@ def test_publish_retry_uploads_only_missing_artifacts(
 
     assert retry.returncode == 0, retry.stderr
     assert (repository_state / "sdist").exists()
-    publish_commands = [
-        line for line in uv_log.read_text().splitlines() if line.startswith("publish ")
-    ]
+    command_records = uv_log.read_text().splitlines()
+    publish_commands = [line for line in command_records if line.startswith("publish ")]
     assert all("--trusted-publishing never" in line for line in publish_commands)
     uploads = [line for line in publish_commands if "--dry-run" not in line]
+    assert all(
+        line.endswith("|token=test-token")
+        if line.startswith("publish ") and "--dry-run" not in line
+        else line.endswith("|token=")
+        for line in command_records
+    )
     assert ".whl" in uploads[0] and ".tar.gz" in uploads[0]
     assert (".whl" in uploads[1]) is (retry_artifact == "both")
     assert ".tar.gz" in uploads[1]

--- a/projects/openshell-middleware-manager/tests/test_release.py
+++ b/projects/openshell-middleware-manager/tests/test_release.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPOSITORY = Path(__file__).resolve().parents[3]
+PUBLISH_SCRIPT = REPOSITORY / "projects/openshell-middleware-manager/scripts/publish.sh"
+PROJECT_MAKEFILE = REPOSITORY / "projects/openshell-middleware-manager/Makefile"
+
+
+def test_publish_prints_tag_deletion_commands_for_existing_remote_tag(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    script = project / "scripts/publish.sh"
+    script.parent.mkdir(parents=True)
+    shutil.copy2(PUBLISH_SCRIPT, script)
+    shutil.copy2(PROJECT_MAKEFILE, project / "Makefile")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "git",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "status" ]]; then exit 0; fi
+        if [[ "$1" == "branch" ]]; then printf 'main\\n'; exit 0; fi
+        if [[ "$1" == "fetch" ]]; then exit 0; fi
+        if [[ "$1" == "rev-parse" && "$2" == "--verify" ]]; then exit 0; fi
+        if [[ "$1" == "rev-parse" ]]; then printf 'abc123\\n'; exit 0; fi
+        if [[ "$1" == "rev-list" ]]; then printf 'abc123\\n'; exit 0; fi
+        if [[ "$1" == "ls-remote" ]]; then
+            printf 'abc123\\trefs/tags/omm-v0.1.0\\n'
+            exit 0
+        fi
+        exit 91
+        """,
+    )
+    environment = os.environ.copy()
+    environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+
+    result = subprocess.run(
+        ["bash", str(script), "0.1.0"],
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "remote tag 'omm-v0.1.0' already exists" in result.stderr
+    assert "git tag -d 'omm-v0.1.0'" in result.stderr
+    assert "git push origin --delete 'omm-v0.1.0'" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("first_accepts_wheel", "retry_artifact"),
+    [(True, "sdist"), (False, "both")],
+)
+def test_publish_retry_uploads_only_missing_artifacts(
+    tmp_path: Path, first_accepts_wheel: bool, retry_artifact: str
+) -> None:
+    project = tmp_path / "project"
+    script = project / "scripts/publish.sh"
+    script.parent.mkdir(parents=True)
+    shutil.copy2(PUBLISH_SCRIPT, script)
+    shutil.copy2(PROJECT_MAKEFILE, project / "Makefile")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "git",
+        """
+        #!/usr/bin/env bash
+        if [[ "$1" == "status" ]]; then exit 0; fi
+        if [[ "$1" == "branch" ]]; then printf 'main\\n'; exit 0; fi
+        if [[ "$1" == "fetch" ]]; then exit 0; fi
+        if [[ "$1" == "rev-parse" && "$2" == "--verify" ]]; then
+            test -e "$FAKE_GIT_STATE/local-tag"
+            exit
+        fi
+        if [[ "$1" == "rev-parse" ]]; then printf 'abc123\\n'; exit 0; fi
+        if [[ "$1" == "rev-list" ]]; then printf 'abc123\\n'; exit 0; fi
+        if [[ "$1" == "ls-remote" ]]; then
+            if [[ -e "$FAKE_GIT_STATE/remote-tag" ]]; then
+                printf 'abc123\\trefs/tags/omm-v0.1.0\\n'
+            fi
+            exit 0
+        fi
+        if [[ "$1" == "tag" && "$2" == "-d" ]]; then
+            rm -f "$FAKE_GIT_STATE/local-tag"
+            exit 0
+        fi
+        if [[ "$1" == "tag" ]]; then
+            touch "$FAKE_GIT_STATE/local-tag"
+            exit 0
+        fi
+        if [[ "$1" == "push" ]]; then
+            touch "$FAKE_GIT_STATE/remote-tag"
+            exit 0
+        fi
+        exit 91
+        """,
+    )
+    _write_executable(
+        fake_bin / "uv",
+        """
+        #!/usr/bin/env bash
+        printf '%s\\n' "$*" >> "$FAKE_UV_LOG"
+        if [[ "$1" == "build" ]]; then
+            mkdir -p dist
+            : > dist/openshell_middleware_manager-0.1.0-py3-none-any.whl
+            : > dist/openshell_middleware_manager-0.1.0.tar.gz
+        fi
+        if [[ "$1" == "publish" && "$*" != *"--dry-run"* ]]; then
+            if [[ "$*" == *".whl"* && "$*" == *".tar.gz"* ]]; then
+                if [[ ! -e "$FAKE_REPOSITORY_STATE/attempted" ]]; then
+                    touch "$FAKE_REPOSITORY_STATE/attempted"
+                    if [[ "$FAKE_FIRST_ACCEPTS_WHEEL" == "true" ]]; then
+                        touch "$FAKE_REPOSITORY_STATE/wheel"
+                    fi
+                    exit 93
+                fi
+                touch "$FAKE_REPOSITORY_STATE/wheel"
+                touch "$FAKE_REPOSITORY_STATE/sdist"
+                exit 0
+            fi
+            if [[ "$*" == *".tar.gz"* ]]; then
+                touch "$FAKE_REPOSITORY_STATE/sdist"
+                exit 0
+            fi
+        fi
+        exit 0
+        """,
+    )
+
+    uv_log = tmp_path / "uv.log"
+    git_state = tmp_path / "git-state"
+    repository_state = tmp_path / "repository-state"
+    git_state.mkdir()
+    repository_state.mkdir()
+    environment = os.environ.copy()
+    environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+    environment["FAKE_UV_LOG"] = str(uv_log)
+    environment["FAKE_GIT_STATE"] = str(git_state)
+    environment["FAKE_REPOSITORY_STATE"] = str(repository_state)
+    environment["FAKE_FIRST_ACCEPTS_WHEEL"] = str(first_accepts_wheel).lower()
+    environment["UV_PUBLISH_TOKEN"] = "test-token"
+    environment["UV"] = "uv"
+
+    first_attempt = subprocess.run(
+        ["bash", str(script), "0.1.0"],
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+    assert first_attempt.returncode == 1
+    assert (repository_state / "wheel").exists() is first_accepts_wheel
+    assert not (repository_state / "sdist").exists()
+
+    retry = subprocess.run(
+        ["bash", str(script), "0.1.0", "--retry-artifact", retry_artifact],
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+
+    assert retry.returncode == 0, retry.stderr
+    assert (repository_state / "sdist").exists()
+    publish_commands = [
+        line for line in uv_log.read_text().splitlines() if line.startswith("publish ")
+    ]
+    assert all("--trusted-publishing never" in line for line in publish_commands)
+    uploads = [line for line in publish_commands if "--dry-run" not in line]
+    assert ".whl" in uploads[0] and ".tar.gz" in uploads[0]
+    assert (".whl" in uploads[1]) is (retry_artifact == "both")
+    assert ".tar.gz" in uploads[1]
+    assert "PyPI: https://pypi.org/project/openshell-middleware-manager/0.1.0/" in retry.stdout
+    if retry_artifact == "sdist":
+        assert "Uploaded the missing sdist artifact" in retry.stdout
+        assert "Published openshell-middleware-manager" not in retry.stdout
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip())
+    path.chmod(0o755)

--- a/projects/openshell-middleware-manager/uv.lock
+++ b/projects/openshell-middleware-manager/uv.lock
@@ -167,7 +167,6 @@ wheels = [
 
 [[package]]
 name = "openshell-middleware-manager"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Summary

- derive package versions from namespaced omm-vX.Y.Z Git tags
- add guarded local PyPI publishing with dry-run and partial-upload retries
- add Make targets, release documentation, PyPI installation guidance, and regression tests
- expose the installed distribution version through omm --version and runtime package metadata
- package the Apache license and keep the PyPI token out of checks and builds

## Validation

- make check
- make build
- uv publish --dry-run for a temporary tagged build
- 95 tests passed with 95.88% coverage
- independent release-correctness, simplicity/scope, and test/API review lenses clean after fixes