### PR TITLE
docs(oar): explain Pi model and inference configuration

### DIFF
--- a/projects/openshell-agent-runner/README.md
+++ b/projects/openshell-agent-runner/README.md
@@ -2,9 +2,11 @@
 
 OpenShell Agent Runner (OAR) launches ephemeral
 [Pi coding agents](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
-in OpenShell sandboxes. Each run executes one task, saves its result to a file,
-and removes the sandbox. Use it to review code, review technical writing, or
-run your own tasks from a terminal or CI job.
+in OpenShell sandboxes. Each agent works on a task using the prompts, skills,
+tools, and permissions defined by its profile. OAR manages task setup,
+execution, result collection, and sandbox cleanup.
+
+The included code and technical writing reviewers follow this workflow:
 
 ```text
 Profile + input → OAR → Pi in a temporary sandbox → Result file

--- a/projects/openshell-agent-runner/README.md
+++ b/projects/openshell-agent-runner/README.md
@@ -1,10 +1,10 @@
 # OpenShell Agent Runner
 
-OpenShell Agent Runner (OAR) is based on the
-[Pi coding agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent).
-It runs Pi in an isolated OpenShell sandbox and saves the task's result to a
-file. Use it to review code, review technical writing, or run your own tasks
-from a terminal or CI job.
+OpenShell Agent Runner (OAR) launches ephemeral
+[Pi coding agents](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
+in OpenShell sandboxes. Each run executes one task, saves its result to a file,
+and removes the sandbox. Use it to review code, review technical writing, or
+run your own tasks from a terminal or CI job.
 
 ```text
 Profile + input → OAR → Pi in a temporary sandbox → Result file

--- a/projects/openshell-agent-runner/README.md
+++ b/projects/openshell-agent-runner/README.md
@@ -1,11 +1,13 @@
 # OpenShell Agent Runner
 
-OpenShell Agent Runner (OAR) runs an agent task in an isolated OpenShell sandbox
-and saves the result to a file. Use it to review code, review technical writing,
-or run your own tasks from a terminal or CI job.
+OpenShell Agent Runner (OAR) is based on the
+[Pi coding agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent).
+It runs Pi in an isolated OpenShell sandbox and saves the task's result to a
+file. Use it to review code, review technical writing, or run your own tasks
+from a terminal or CI job.
 
 ```text
-Profile + input → OAR → Agent in a temporary sandbox → Result file
+Profile + input → OAR → Pi in a temporary sandbox → Result file
                             sandbox removed when the run ends
 ```
 
@@ -26,6 +28,14 @@ If OpenShell is not ready, follow its
 [quickstart](https://docs.nvidia.com/openshell/latest/get-started/quickstart).
 OAR uses that setup to create sandboxes and reach your model.
 
+Pi supplies the agent loop, tools, and model client. Each OAR profile supplies
+Pi's `models.json` and `settings.json`; OpenShell supplies the inference route
+and provider credentials. The packaged profiles send OpenAI-compatible Chat
+Completions requests to `https://inference.local/v1`. Your model and endpoint
+must support that API and tool calling. See
+[model and inference configuration](https://nvidia.github.io/OpenShell-Research/documentation/openshell-agent-runner/profiles/#configure-pis-model-and-inference)
+for the file formats, reasoning settings, and compatibility options.
+
 **1. Install OAR and check your connection.**
 
 ```bash
@@ -45,8 +55,10 @@ the inference output from `oar doctor`.
 oar init ./profiles --model YOUR_MODEL_ID
 ```
 
-This creates editable copies of both reviewers. For a model without reasoning
-support, add `--thinking off`.
+This creates editable copies of both reviewers and sets the model ID in both
+Pi configuration files. For a model without reasoning support, add
+`--thinking off`; this also sets the model's `reasoning` flag to `false`.
+`init` writes local profiles; configure the inference route through OpenShell.
 
 **3. Review a document.** Replace `./README.md` with an existing text file.
 

--- a/projects/openshell-agent-runner/docs/assets/diagrams/system-overview.svg
+++ b/projects/openshell-agent-runner/docs/assets/diagrams/system-overview.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 760" role="img" aria-labelledby="title description">
   <title id="title">Independent OAR runs on one OpenShell gateway</title>
-  <desc id="description">Three separate oar run invocations share one OpenShell gateway. Runs 1 and 3 use the code-reviewer profile on different projects. Run 2 uses technical-writing-reviewer on a document. Each profile supplies the selected task's prompt and skills. Each run uploads its own input to a separate sandbox, runs an agent with those instructions, and returns its own result file. OAR removes each sandbox when its task finishes; the gateway remains available.</desc>
+  <desc id="description">Three separate oar run invocations share one OpenShell gateway. Runs 1 and 3 use the code-reviewer profile on different projects. Run 2 uses technical-writing-reviewer on a document. Each profile supplies the selected task's prompt and skills. Each run uploads its own input to a separate sandbox, runs Pi with those instructions, and returns its own result file. OAR removes each sandbox when its task finishes; the gateway remains available.</desc>
   <defs>
     <style>
       text{font-family:system-ui,-apple-system,"Segoe UI",sans-serif;fill:#24352c}
@@ -73,7 +73,7 @@
 
   <rect x="356" y="155" width="438" height="155" rx="10" class="sandbox"/>
   <text x="376" y="180" class="label">Sandbox 1</text>
-  <text x="774" y="180" text-anchor="end" class="small">Agent + uploaded files</text>
+  <text x="774" y="180" text-anchor="end" class="small">Pi + uploaded files</text>
   <g role="group" aria-label="code-reviewer profile: task prompt and skills">
     <rect x="372" y="194" width="406" height="102" rx="7" class="profile-bundle"/>
     <text x="388" y="220" class="mono profile">code-reviewer</text>
@@ -99,7 +99,7 @@
 
   <rect x="356" y="337" width="438" height="155" rx="10" class="sandbox writing"/>
   <text x="376" y="362" class="label">Sandbox 2</text>
-  <text x="774" y="362" text-anchor="end" class="small">Agent + uploaded files</text>
+  <text x="774" y="362" text-anchor="end" class="small">Pi + uploaded files</text>
   <g role="group" aria-label="technical-writing-reviewer profile: task prompt and skills">
     <rect x="372" y="376" width="406" height="102" rx="7" class="profile-bundle profile-writing"/>
     <text x="388" y="402" class="mono profile">technical-writing-reviewer</text>
@@ -125,7 +125,7 @@
 
   <rect x="356" y="519" width="438" height="155" rx="10" class="sandbox"/>
   <text x="376" y="544" class="label">Sandbox 3</text>
-  <text x="774" y="544" text-anchor="end" class="small">Agent + uploaded files</text>
+  <text x="774" y="544" text-anchor="end" class="small">Pi + uploaded files</text>
   <g role="group" aria-label="code-reviewer profile: task prompt and skills">
     <rect x="372" y="558" width="406" height="102" rx="7" class="profile-bundle"/>
     <text x="388" y="584" class="mono profile">code-reviewer</text>

--- a/projects/openshell-agent-runner/docs/index.md
+++ b/projects/openshell-agent-runner/docs/index.md
@@ -6,11 +6,11 @@ agent_markdown: true
 
 # OpenShell Agent Runner
 
-OpenShell Agent Runner (OAR) is based on the
-[Pi coding agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent).
-It runs Pi in an isolated OpenShell sandbox and saves the task's result to a
-file. Use it to review a project, improve a technical document, or run your own
-tasks from a terminal or CI job.
+OpenShell Agent Runner (OAR) launches ephemeral
+[Pi coding agents](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
+in OpenShell sandboxes. Each run executes one task, saves its result to a file,
+and removes the sandbox. Use it to review a project, improve a technical
+document, or run your own tasks from a terminal or CI job.
 
 Pi supplies the agent loop, tools, skills, and model client. OAR prepares the
 task, launches Pi, collects the result, and removes the sandbox. OpenShell

--- a/projects/openshell-agent-runner/docs/index.md
+++ b/projects/openshell-agent-runner/docs/index.md
@@ -8,9 +8,9 @@ agent_markdown: true
 
 OpenShell Agent Runner (OAR) launches ephemeral
 [Pi coding agents](https://github.com/earendil-works/pi/tree/main/packages/coding-agent)
-in OpenShell sandboxes. Each run executes one task, saves its result to a file,
-and removes the sandbox. Use it to review a project, improve a technical
-document, or run your own tasks from a terminal or CI job.
+in OpenShell sandboxes. Each agent works on a task using the prompts, skills,
+tools, and permissions defined by its profile. Use OAR to run the included
+reviewers or your own agent workflows from a terminal or CI job.
 
 Pi supplies the agent loop, tools, skills, and model client. OAR prepares the
 task, launches Pi, collects the result, and removes the sandbox. OpenShell

--- a/projects/openshell-agent-runner/docs/index.md
+++ b/projects/openshell-agent-runner/docs/index.md
@@ -6,15 +6,21 @@ agent_markdown: true
 
 # OpenShell Agent Runner
 
-OpenShell Agent Runner (OAR) runs an agent task in an isolated OpenShell sandbox
-and saves the result to a file. Use it to review a project, improve a technical
-document, or run your own tasks from a terminal or CI job.
+OpenShell Agent Runner (OAR) is based on the
+[Pi coding agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent).
+It runs Pi in an isolated OpenShell sandbox and saves the task's result to a
+file. Use it to review a project, improve a technical document, or run your own
+tasks from a terminal or CI job.
+
+Pi supplies the agent loop, tools, skills, and model client. OAR prepares the
+task, launches Pi, collects the result, and removes the sandbox. OpenShell
+provides isolation and routes Pi's inference requests to your model.
 
 <figure class="documentation-figure documentation-figure--wide">
   <a href="assets/diagrams/system-overview.svg" aria-label="Open the OAR architecture diagram at full size">
-    <img src="assets/diagrams/system-overview.svg" alt="Three independent OAR runs share one OpenShell gateway. Each sandbox uses a profile containing prompts and skills: code-reviewer for two runs and technical-writing-reviewer for one. Inputs and results remain separate for each run.">
+    <img src="assets/diagrams/system-overview.svg" alt="Three independent OAR runs share one OpenShell gateway. Pi runs in each sandbox with a profile containing prompts and skills: code-reviewer for two runs and technical-writing-reviewer for one. Inputs and results remain separate for each run.">
   </a>
-  <figcaption>Each profile supplies prompts and skills to its agent. Runs stay isolated, even when they share a profile. Select the diagram to view it at full size.</figcaption>
+  <figcaption>Each profile supplies prompts and skills to Pi. Runs stay isolated, even when they share a profile. Select the diagram to view it at full size.</figcaption>
 </figure>
 
 A **profile** packages task prompts, reusable skills, model settings, and sandbox
@@ -31,7 +37,9 @@ OpenShell 0.0.111 or newer. You need a running **gateway** and configured
 if you have not set these up yet.
 
 OAR uses your existing OpenShell configuration. API keys and provider setup
-belong there.
+belong there. The packaged profiles configure Pi to send OpenAI-compatible
+Chat Completions requests to `https://inference.local/v1`. Choose a model and
+endpoint that support that API and tool calling.
 
 ## 1. Install and check the connection
 
@@ -67,7 +75,11 @@ profiles/
 ```
 
 The default thinking level is `high`. For a model without reasoning support,
-add `--thinking off` to `init`.
+add `--thinking off` to `init`; it also sets `reasoning: false` in Pi's model
+definition. `init` writes the model ID into the profile's `models.json` and
+`settings.json`. It does not configure or change OpenShell's inference route.
+See [model and inference configuration](profiles.md#configure-pis-model-and-inference)
+to understand these files or adapt them to your endpoint.
 
 ## 3. Run your first review
 

--- a/projects/openshell-agent-runner/docs/profiles.md
+++ b/projects/openshell-agent-runner/docs/profiles.md
@@ -19,8 +19,8 @@ code-reviewer/
 ├── skills/              Reusable review guidance and rubric
 ├── schemas/review.json   Required shape of the result
 ├── policy.yaml          Sandbox file and network permissions
-├── models.json          Model definition
-└── settings.json        Selected model and thinking level
+├── models.json          Pi model definition and API compatibility
+└── settings.json        Pi provider, model, and thinking level
 ```
 
 | What you want to change | Where to change it |
@@ -30,8 +30,104 @@ code-reviewer/
 | Shared judgment, conventions, or scoring | A skill's `SKILL.md` |
 | Tasks, tools, or which skills are loaded | `profile.yaml` |
 | What the sandbox can access | `policy.yaml` |
-| The model | Keep the ID in `models.json` and `settings.json` in sync with your inference route |
+| The model or inference compatibility | [Pi model and inference configuration](#configure-pis-model-and-inference) in `models.json` and `settings.json` |
 | The result's JSON fields | The schema and the instructions that explain those fields |
+
+## Configure Pi's model and inference
+
+OAR uses the Pi coding agent, so model configuration follows Pi's file formats.
+For each run, OAR copies the profile's `models.json` and `settings.json` into
+Pi's isolated configuration directory inside the sandbox. Your host Pi
+installation, login, and `~/.pi/agent` settings are not used.
+
+Configuration has two parts:
+
+| Configuration | What it controls |
+| --- | --- |
+| OpenShell provider and inference route | The upstream endpoint, credentials, and model served through the selected gateway and workspace. Manage these through OpenShell. |
+| Pi files in the OAR profile | How Pi formats requests, the model it selects, and its reasoning settings. Edit these locally or create them with `oar init`. |
+
+The packaged profiles use this request path:
+
+```text
+Pi → OpenAI-compatible Chat Completions → https://inference.local/v1
+   → OpenShell inference route → configured upstream model
+```
+
+### Model definition
+
+After `oar init ./profiles --model YOUR_MODEL_ID`, each profile's `models.json`
+contains:
+
+```json
+{
+  "providers": {
+    "openshell": {
+      "baseUrl": "https://inference.local/v1",
+      "api": "openai-completions",
+      "apiKey": "unused",
+      "authHeader": true,
+      "compat": {
+        "supportsDeveloperRole": false
+      },
+      "models": [
+        {
+          "id": "YOUR_MODEL_ID",
+          "reasoning": true
+        }
+      ]
+    }
+  }
+}
+```
+
+`openshell` is Pi's provider name within the profile; keep it even when
+OpenShell routes to a differently named upstream provider. OAR requires exactly
+one provider named `openshell` and exactly one model under it.
+
+`baseUrl` points Pi at OpenShell's sandbox inference endpoint. `apiKey: "unused"`
+is a placeholder sent with a bearer authorization header; actual upstream
+credentials belong in OpenShell's provider configuration.
+
+`api: "openai-completions"` selects Pi's OpenAI Chat Completions client. It does
+not require an OpenAI-hosted model, but the routed endpoint must accept that
+protocol and support the tool calls Pi uses. `compat.supportsDeveloperRole:
+false` makes Pi send the system prompt with the `system` role. Other endpoint
+differences may require Pi compatibility options, such as
+`compat.supportsReasoningEffort: false` for a server that rejects
+`reasoning_effort`. Model limits such as `contextWindow` and `maxTokens` also
+belong in `models.json`. See Pi's
+[custom model reference](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md)
+for field definitions. Any API choice must also work with your OpenShell route.
+
+### Model selection and reasoning
+
+The corresponding `settings.json` contains only these three keys:
+
+```json
+{
+  "defaultProvider": "openshell",
+  "defaultModel": "YOUR_MODEL_ID",
+  "defaultThinkingLevel": "high"
+}
+```
+
+OAR checks that `defaultModel` matches the model's `id` in `models.json` and
+passes this provider, model, and thinking level to Pi at launch. Additional Pi
+settings keys are rejected by OAR.
+
+`oar init --thinking off` sets `defaultThinkingLevel` to `off` and the model's
+`reasoning` flag to `false`. Other levels set `reasoning` to `true`; they are
+`minimal`, `low`, `medium`, `high` (the default), `xhigh`, and `max`. Choose a
+level supported by your model and endpoint. These are Pi reasoning settings;
+`init` does not discover model capabilities or test inference.
+
+When changing models, first configure the route in OpenShell and inspect it
+with `oar doctor` using the same gateway and workspace as your run. Update both
+`models.json`'s model `id` and `settings.json`'s `defaultModel` to that model ID,
+then adjust reasoning, limits, and compatibility for the new model. Run
+`oar validate` against the profile and try a task to verify inference; local
+validation and `doctor` do not send model requests.
 
 ## How a task is defined
 

--- a/projects/openshell-agent-runner/docs/profiles.md
+++ b/projects/openshell-agent-runner/docs/profiles.md
@@ -226,6 +226,13 @@ access, including commands run through `bash`.
 
 ## Choose the result format
 
+The result file is what OAR returns to the caller. A task can also modify files
+or act on external services when its tools, credentials, and sandbox policy
+allow it. OAR currently downloads only the result file; it does not synchronize
+code changes back to your machine. Work that must persist needs to be exported
+or pushed before sandbox cleanup. Removing the sandbox does not undo actions
+already taken on external services, such as opening a pull request.
+
 The result schema is a JSON file **in your profile**. Each task names the file
 through `output_schema` in `profile.yaml`. For the included reviewers, `oar init`
 copies `schemas/review.json` into the profile; you can edit it to change the

--- a/projects/openshell-agent-runner/docs/reference.md
+++ b/projects/openshell-agent-runner/docs/reference.md
@@ -19,7 +19,10 @@ agent_markdown: true
 `init` creates both profiles by default. Repeat `--profile NAME` to select
 which ones to create. It refuses to overwrite existing profile directories.
 `--thinking` accepts `off`, `minimal`, `low`, `medium`, `high` (default),
-`xhigh`, or `max`; choose a level your model supports.
+`xhigh`, or `max`; choose a level your model supports. It sets Pi's
+`defaultThinkingLevel` and sets the model's `reasoning` flag to `false` for
+`off`, or `true` otherwise. `--model` sets the model ID in both Pi files.
+See [model and inference configuration](profiles.md#configure-pis-model-and-inference).
 
 Use `oar COMMAND --help` for all options. For a task's inputs, variables, and
 output format, put the profile and task before `--help`:
@@ -102,7 +105,7 @@ one result. OAR checks the request before attempting to create the sandbox.
 2. RUN · new OpenShell sandbox
    Create using the profile's policy
    Upload input, prompt, skills + schema*
-   Run the agent using gateway inference
+   Run Pi with the profile's model settings using gateway inference
               |
               v
 3. COLLECT · your machine / CI
@@ -161,7 +164,7 @@ For this repository's workflow and PR reports, see the
 | --- | --- |
 | `oar: command not found` after installation | Run `uv tool update-shell`, then open a new terminal. |
 | `doctor` cannot connect | Check OpenShell gateway status and that you selected the intended gateway. |
-| No inference route or model request fails | Check the route in OpenShell, then the model ID and thinking level in your profile. |
+| No inference route or model request fails | Check the OpenShell route, then [Pi's model ID, API compatibility, and reasoning settings](profiles.md#configure-pis-model-and-inference). The packaged profiles require OpenAI-compatible Chat Completions with tool calling. |
 | `init` says a profile already exists | Use the existing profile or choose a new destination. |
 | Unknown task or prompt variable | Run task-specific `--help` and check `profile.yaml`. |
 | Missing or invalid result | Read the run's errors; use `--keep-sandbox` on the next run to inspect it. |


### PR DESCRIPTION
OAR's documentation barely identified Pi as its underlying coding agent and did not explain how Pi's model configuration relates to OpenShell inference. Make that relationship explicit in the README, getting-started guide, and architecture diagram.

Add a configuration guide with matching `models.json` and `settings.json` examples, explaining OpenShell routing and credentials, Pi provider/model selection, Chat Completions and tool-calling requirements, reasoning settings, compatibility options, and the steps for changing models. Link it from setup and troubleshooting.

Validation:
- `make check`: all 153 OAR tests, formatting, lint, type, and syntax checks passed.
- `make build`: source distribution and wheel built successfully.
- Documentation tests: 23 passed, 3 skipped before the site build; direct Dev Notes renderer tests passed.
- `scripts/build-docs.sh`: strict build and all post-build checks passed.
- JSON examples match packaged profiles; published Markdown and configuration anchor verified.
- Served the built site locally and confirmed the configuration page returned HTTP 200.
