### PR TITLE
docs: add exporter deployment guides and configuration reference

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -9,6 +9,8 @@ agent_markdown: true
 Technical documentation and references for installing, using, and extending
 OpenShell Research projects.
 
+- [OpenShell Event Exporter](openshell-exporter/index.md): install and configure
+  the container images for exporting OpenShell evidence.
 - [Egress Gate](egress-gate/index.md): extensible middleware for applying gates
   to outgoing HTTP requests.
 - [OpenShell Agent Runner](openshell-agent-runner/index.md): launch ephemeral

--- a/docs/documentation/openshell-exporter/compose.yaml
+++ b/docs/documentation/openshell-exporter/compose.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+services:
+  exporter:
+    image: ${EXPORTER_IMAGE:-ghcr.io/nvidia/openshell-exporter:v0.0.5-rc.1}
+    user: "${EXPORTER_UID:?Set EXPORTER_UID in .env}:${EXPORTER_GID:?Set EXPORTER_GID in .env}"
+    command: ["--config", "/etc/exporter.yaml"]
+    read_only: true
+    tmpfs: ["/tmp:rw,noexec,nosuid,size=16m"]
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    mem_limit: 512m
+    restart: unless-stopped
+    ports: ["127.0.0.1:23133:13133"]
+    environment:
+      OPENSHELL_ENDPOINT: ${OPENSHELL_ENDPOINT:-}
+      OPENSHELL_GATEWAY_ID: ${OPENSHELL_GATEWAY_ID:-local-gateway}
+      OPENSHELL_WORKSPACE: ${OPENSHELL_WORKSPACE:-default}
+      OPENSHELL_SANDBOX_NAME: ${OPENSHELL_SANDBOX_NAME:-}
+      OPENSHELL_EXPORT_URL: ${OPENSHELL_EXPORT_URL:-}
+    volumes:
+      - ./config.yaml:/etc/exporter.yaml:ro,Z
+      - ./input:/input:ro,Z
+      - ./state:/state:Z
+      - ./output:/output:Z
+      - ./secrets:/run/secrets:ro,Z

--- a/docs/documentation/openshell-exporter/config.yaml
+++ b/docs/documentation/openshell-exporter/config.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+extensions:
+  file_storage/checkpoints:
+    directory: /state/checkpoints
+    create_directory: true
+  storagehealth:
+    paths:
+      checkpoints: /state/checkpoints
+      recovery: /output/events.json
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  file_log/ocsf:
+    include: [/input/*.jsonl]
+    start_at: beginning
+    storage: file_storage/checkpoints
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+    include_file_path: true
+    include_file_path_resolved: true
+    include_file_record_offset: true
+    include_file_record_number: true
+    on_truncate: read_whole_file
+    max_log_size: 8MiB
+    max_log_size_behavior: split
+    attributes:
+      openshell.acquisition.kind: ocsf.file
+      openshell.acquisition.source_instance: sandbox-ocsf-jsonl
+    operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: body
+        on_error: send
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+    spike_limit_mib: 64
+  openshell:
+    source_profiles: [ocsf.file]
+    gateway_id: local-gateway
+    workspace: default
+    source_instance: gateway-ocsf-jsonl
+    validation:
+      mode: mark
+
+exporters:
+  file/recovery:
+    path: /output/events.json
+    format: json
+    append: true
+
+service:
+  telemetry:
+    logs:
+      encoding: json
+    metrics:
+      level: none
+  extensions: [file_storage/checkpoints, storagehealth, health_check]
+  pipelines:
+    logs:
+      receivers: [file_log/ocsf]
+      processors: [memory_limiter, openshell]
+      exporters: [file/recovery]

--- a/docs/documentation/openshell-exporter/configuration.md
+++ b/docs/documentation/openshell-exporter/configuration.md
@@ -1,0 +1,91 @@
+---
+title: Configure sources and delivery
+description: Choose local files or an existing gateway and configure credentials, destinations, and durable storage.
+agent_markdown: true
+---
+
+# Configure sources and delivery
+
+All deployment paths run the same image and accept standard Collector YAML.
+Choose one of these ready-to-edit configurations:
+
+| Configuration | Input | Output |
+| --- | --- | --- |
+| [config.yaml](config.yaml) | Local OCSF JSONL files | Normalized recovery records in `/output/events.json`. |
+| [gateway.yaml](gateway.yaml) | WatchSandbox and policy snapshots from an existing gateway | HTTPS CloudEvents plus local recovery records. |
+
+## Read existing files
+
+With the starter configuration, place authorized OCSF JSONL files in `input/`.
+Each file must end in `.jsonl`, with one JSON object per line. Replace the
+processor's `gateway_id` and `workspace` with your source identity. Keep these
+values, `source_instance`, and file paths stable across restarts.
+
+Retain files, including rotated files, until collected. One exporter owns each
+writable checkpoint directory. Do not also collect the same files through a
+forwarder.
+
+## Connect a gateway and destination
+
+You need an existing HTTPS gateway, read-only gateway credentials, an authorized
+sandbox name, and an HTTPS receiver that accepts CloudEvents JSON batches. This
+setup does not create a gateway, agent, inference route, or destination.
+
+For Docker or Podman, download the gateway profile as your active configuration:
+
+```sh
+curl -fL https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter/gateway.yaml -o config.yaml
+```
+
+Add these non-secret settings to `.env`, replacing the examples. Keep the UID/GID
+entries already created by the Docker quickstart:
+
+```dotenv
+OPENSHELL_ENDPOINT=https://gateway.example.com:8080
+OPENSHELL_GATEWAY_ID=gateway-1
+OPENSHELL_WORKSPACE=default
+OPENSHELL_SANDBOX_NAME=my-sandbox
+OPENSHELL_EXPORT_URL=https://receiver.example.com/v1/events
+```
+
+Place the raw gateway token in `secrets/gateway-token` and the separate raw
+destination token in `secrets/destination-token`, without the `Bearer` prefix.
+Make the files readable only by the user running the exporter, for example with
+`chmod 600 secrets/gateway-token secrets/destination-token`. Keep credentials
+out of `.env` and version control.
+
+For private CAs, place certificates in `secrets/` and add `tls.ca_file` under the
+appropriate receiver/exporter, using paths such as `/run/secrets/gateway-ca.pem`.
+For mTLS, add paired `tls.cert_file` and `tls.key_file` paths. Retain verified TLS;
+do not disable verification to work around a missing CA.
+
+Validate and recreate the container using the [Docker](docker.md) or
+[Podman](podman.md) instructions. For Kubernetes, the [Helm guide](helm.md) mounts
+these same files from a Secret and supplies settings through values.
+
+Generate authorized activity in the selected sandbox and confirm records arrive
+at your destination. Check the recovery file too when running locally. A healthy
+process does not establish end-to-end delivery.
+
+## Operate and extend
+
+Keep `/state/checkpoints`, `/state/cloudevents-queue`, and `/output` persistent.
+Recovery output appends across restarts. Queue capacity is bounded; monitor disk
+space, restrict access to retained evidence, and arrange retention according to
+your environment. Never delete state automatically to recover space.
+
+CloudEvents receivers must deduplicate by `(source,id)` because delivery can be
+retried. WatchSandbox cannot resume a disconnected stream; policy snapshots do
+not reconstruct every missed change. Malformed input is marked rather than
+silently dropped.
+
+Inspect additional components with `docker run --rm IMAGE components` (or
+`podman run --rm IMAGE components`), replacing `IMAGE` with your pinned exporter
+image. Relay and native OTLP need separate pipelines, authenticated TLS inputs,
+and their own destination queues. Use the `relay` processor with
+`privacy.mode: allow` for Relay input before delivery.
+
+The optional `ghcr.io/nvidia/openshell-otlp-proxy:v0.0.5-rc.1` image adds a
+workload-local OTLP/HTTP queue. It does not filter content; its queue may retain
+unfiltered input. The basic deployments above do not need this proxy. See the
+[release status](index.md) before using either image.

--- a/docs/documentation/openshell-exporter/configuration.md
+++ b/docs/documentation/openshell-exporter/configuration.md
@@ -6,13 +6,31 @@ agent_markdown: true
 
 # Configure sources and delivery
 
-All deployment paths run the same image and accept standard Collector YAML.
-Choose one of these ready-to-edit configurations:
+All deployment paths run the same image. Docker and Podman accept these
+ready-to-edit Collector configurations; the [Helm chart](helm.md) generates its
+configuration from chart values:
 
 | Configuration | Input | Output |
 | --- | --- | --- |
 | [config.yaml](config.yaml) | Local OCSF JSONL files | Normalized recovery records in `/output/events.json`. |
 | [gateway.yaml](gateway.yaml) | WatchSandbox and policy snapshots from an existing gateway | HTTPS CloudEvents plus local recovery records. |
+
+## Full configuration template
+
+Download [template.config.yaml](template.config.yaml) for every exporter-specific
+setting and examples of all included component types. It includes comments for
+credentials, TLS, redaction, Relay/native OTLP, Kubernetes context, durable queues,
+and edge/central forwarding. Advanced upstream transport/parser options are
+outside its scope. Keep the quickstart small; use this reference when extending it.
+
+```sh
+curl -fL https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter/template.config.yaml -o template.config.yaml
+```
+
+Copy the sections you need into `config.yaml`, remove unused definitions, supply
+the referenced secret files, and validate with the Docker or Podman instructions
+before starting. Helm users configure these capabilities through chart values;
+this Collector template is not a Helm values file.
 
 ## Read existing files
 
@@ -60,8 +78,8 @@ For mTLS, add paired `tls.cert_file` and `tls.key_file` paths. Retain verified T
 do not disable verification to work around a missing CA.
 
 Validate and recreate the container using the [Docker](docker.md) or
-[Podman](podman.md) instructions. For Kubernetes, the [Helm guide](helm.md) mounts
-these same files from a Secret and supplies settings through values.
+[Podman](podman.md) instructions. For Kubernetes, the [Helm guide](helm.md) uses
+separate token and TLS Secrets and supplies settings through chart values.
 
 Generate authorized activity in the selected sandbox and confirm records arrive
 at your destination. Check the recovery file too when running locally. A healthy

--- a/docs/documentation/openshell-exporter/docker.md
+++ b/docs/documentation/openshell-exporter/docker.md
@@ -1,0 +1,64 @@
+---
+title: Deploy with Docker
+description: Run and manage the exporter with Docker Compose and persistent local directories.
+agent_markdown: true
+---
+
+# Deploy with Docker
+
+Follow the [quickstart](index.md#quickstart-with-docker) to download
+[compose.yaml](compose.yaml) and [config.yaml](config.yaml), then start the image.
+Docker Desktop on Intel/Apple Silicon Macs and Docker Engine on Linux AMD64/ARM64
+use the same files. Leave `platform` unset so Docker selects the native image.
+
+The [release status](index.md) applies to all image commands on this page.
+
+## Configure and start
+
+The local `.env` records your UID/GID so the exporter can write its bind-mounted
+state and output. Use [the configuration guide](configuration.md) to select a file
+source or gateway and destination. Credentials go in `secrets/`; `.env` contains
+only settings such as endpoints and the image reference.
+
+From the directory containing `compose.yaml`:
+
+```sh
+docker compose run --rm exporter validate --config /etc/exporter.yaml
+docker compose up -d --force-recreate --wait
+docker compose ps
+docker compose logs --tail 30 exporter
+curl --fail http://127.0.0.1:23133/
+```
+
+Confirm real records appear in `output/events.json` and, if configured, at your
+destination. The container runs with your UID/GID, a read-only root filesystem,
+a 512 MiB memory limit, and health bound to localhost on the host.
+
+| Local path | Purpose |
+| --- | --- |
+| `config.yaml` | Collector configuration, mounted read-only. |
+| `input/` | Authorized JSONL files, mounted read-only. |
+| `state/` | Persistent checkpoints and destination queues. |
+| `output/` | Recovery records, preserved across restarts. |
+| `secrets/` | Gateway/destination credentials and optional TLS files, mounted read-only. |
+
+## Stop, update, or upgrade
+
+```sh
+docker compose stop
+docker compose start
+```
+
+After editing configuration, validate it and use `up -d --force-recreate --wait`
+so the container reads the new file. For an image upgrade, set `EXPORTER_IMAGE`
+to the released version or digest in `.env`, then:
+
+```sh
+docker compose pull
+docker compose run --rm exporter validate --config /etc/exporter.yaml
+docker compose up -d --force-recreate --wait
+```
+
+Keep a copy of the previous configuration and image reference for rollback.
+`docker compose down` removes the containers and network; the bind-mounted local
+directories remain. Never share writable state with another exporter.

--- a/docs/documentation/openshell-exporter/gateway.yaml
+++ b/docs/documentation/openshell-exporter/gateway.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+extensions:
+  bearertokenauth/destination:
+    filename: /run/secrets/destination-token
+  file_storage/checkpoints:
+    directory: /state/checkpoints
+    create_directory: true
+  file_storage/cloudevents_queue:
+    directory: /state/cloudevents-queue
+    create_directory: true
+  storagehealth:
+    paths:
+      checkpoints: /state/checkpoints
+      cloudevents_queue: /state/cloudevents-queue
+      recovery: /output/events.json
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  watchsandbox:
+    endpoint: ${env:OPENSHELL_ENDPOINT}
+    gateway_id: ${env:OPENSHELL_GATEWAY_ID}
+    workspace: ${env:OPENSHELL_WORKSPACE}
+    sandbox_names: ["${env:OPENSHELL_SANDBOX_NAME}"]
+    token_env: ""
+    token_file: /run/secrets/gateway-token
+    policy_reconciliation:
+      enabled: true
+      storage: file_storage/checkpoints
+      include_effective_policies: false
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+    spike_limit_mib: 64
+  openshell:
+    source_profiles: [watchsandbox, policy.reconciliation]
+    gateway_id: ${env:OPENSHELL_GATEWAY_ID}
+    workspace: ${env:OPENSHELL_WORKSPACE}
+    source_instance: gateway-watch
+    validation:
+      mode: mark
+
+exporters:
+  cloudevents:
+    endpoint: ${env:OPENSHELL_EXPORT_URL}
+    auth:
+      authenticator: bearertokenauth/destination
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+    sending_queue:
+      enabled: true
+      storage: file_storage/cloudevents_queue
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+  file/recovery:
+    path: /output/events.json
+    format: json
+    append: true
+
+service:
+  telemetry:
+    logs:
+      encoding: json
+    metrics:
+      level: none
+  extensions: [bearertokenauth/destination, file_storage/checkpoints, file_storage/cloudevents_queue, storagehealth, health_check]
+  pipelines:
+    logs:
+      receivers: [watchsandbox]
+      processors: [memory_limiter, openshell]
+      exporters: [cloudevents, file/recovery]

--- a/docs/documentation/openshell-exporter/helm-values.yaml
+++ b/docs/documentation/openshell-exporter/helm-values.yaml
@@ -1,113 +1,29 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
-# SPDX-License-Identifier: Apache-2.0
-# For open-telemetry/opentelemetry-collector chart 0.173.0.
-mode: statefulset
+# The published chart supplies the matching multi-platform image digest.
 fullnameOverride: openshell-exporter
-replicaCount: 1
+profile: stream
+
+source:
+  endpoint: https://gateway.example.com:8080
+  gatewayId: gateway-1
+  workspace: default
+  # Replace with a label selector matching only your authorized sandboxes.
+  sandboxSelector: observability=enabled
+  sourceInstance: kubernetes-gateway
+  bearerEnabled: true
+  mtlsEnabled: false
+
+destination:
+  cloudEvents:
+    endpoint: https://receiver.example.com/v1/events
+    mtlsEnabled: false
+
 nodeSelector:
   kubernetes.io/os: linux
-image:
-  repository: ghcr.io/nvidia/openshell-exporter
-  tag: v0.0.5-rc.1
-command:
-  name: usr/local/bin/openshell-event-exporter
-configMap:
-  create: false
-  existingName: openshell-exporter-config
-serviceAccount:
-  automountServiceAccountToken: false
-clusterRole:
-  create: false
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 65532
-  runAsGroup: 65532
-  fsGroup: 65532
-  fsGroupChangePolicy: OnRootMismatch
-  seccompProfile:
-    type: RuntimeDefault
-securityContext:
-  readOnlyRootFilesystem: true
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop: [ALL]
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: "1"
-    memory: 512Mi
-extraEnvs:
-  - name: OPENSHELL_ENDPOINT
-    value: https://gateway.example.com:8080
-  - name: OPENSHELL_GATEWAY_ID
-    value: gateway-1
-  - name: OPENSHELL_WORKSPACE
-    value: default
-  - name: OPENSHELL_SANDBOX_NAME
-    value: my-sandbox
-  - name: OPENSHELL_EXPORT_URL
-    value: https://receiver.example.com/v1/events
-extraVolumes:
-  - name: credentials
-    secret:
-      secretName: openshell-exporter-auth
-      defaultMode: 0440
-  - name: input
-    emptyDir: {}
-  - name: tmp
-    emptyDir:
-      medium: Memory
-      sizeLimit: 16Mi
-extraVolumeMounts:
-  - name: credentials
-    mountPath: /run/secrets
-    readOnly: true
-  - name: input
-    mountPath: /input
-    readOnly: true
-  - name: state
-    mountPath: /state
-  - name: output
-    mountPath: /output
-  - name: tmp
-    mountPath: /tmp
-statefulset:
-  volumeClaimTemplates:
-    - metadata:
-        name: state
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 1Gi
-    - metadata:
-        name: output
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 5Gi
-ports:
-  otlp:
-    enabled: false
-  otlp-http:
-    enabled: false
-  jaeger-compact:
-    enabled: false
-  jaeger-thrift:
-    enabled: false
-  jaeger-grpc:
-    enabled: false
-  zipkin:
-    enabled: false
-  metrics:
-    enabled: false
-  health:
-    enabled: true
-    containerPort: 13133
-    servicePort: 13133
-    protocol: TCP
-service:
-  type: ClusterIP
+
+persistence:
+  queue:
+    size: 5Gi
+  recovery:
+    size: 5Gi
+  checkpoints:
+    size: 1Gi

--- a/docs/documentation/openshell-exporter/helm-values.yaml
+++ b/docs/documentation/openshell-exporter/helm-values.yaml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+# For open-telemetry/opentelemetry-collector chart 0.173.0.
+mode: statefulset
+fullnameOverride: openshell-exporter
+replicaCount: 1
+nodeSelector:
+  kubernetes.io/os: linux
+image:
+  repository: ghcr.io/nvidia/openshell-exporter
+  tag: v0.0.5-rc.1
+command:
+  name: usr/local/bin/openshell-event-exporter
+configMap:
+  create: false
+  existingName: openshell-exporter-config
+serviceAccount:
+  automountServiceAccountToken: false
+clusterRole:
+  create: false
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+extraEnvs:
+  - name: OPENSHELL_ENDPOINT
+    value: https://gateway.example.com:8080
+  - name: OPENSHELL_GATEWAY_ID
+    value: gateway-1
+  - name: OPENSHELL_WORKSPACE
+    value: default
+  - name: OPENSHELL_SANDBOX_NAME
+    value: my-sandbox
+  - name: OPENSHELL_EXPORT_URL
+    value: https://receiver.example.com/v1/events
+extraVolumes:
+  - name: credentials
+    secret:
+      secretName: openshell-exporter-auth
+      defaultMode: 0440
+  - name: input
+    emptyDir: {}
+  - name: tmp
+    emptyDir:
+      medium: Memory
+      sizeLimit: 16Mi
+extraVolumeMounts:
+  - name: credentials
+    mountPath: /run/secrets
+    readOnly: true
+  - name: input
+    mountPath: /input
+    readOnly: true
+  - name: state
+    mountPath: /state
+  - name: output
+    mountPath: /output
+  - name: tmp
+    mountPath: /tmp
+statefulset:
+  volumeClaimTemplates:
+    - metadata:
+        name: state
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: output
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 5Gi
+ports:
+  otlp:
+    enabled: false
+  otlp-http:
+    enabled: false
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+  metrics:
+    enabled: false
+  health:
+    enabled: true
+    containerPort: 13133
+    servicePort: 13133
+    protocol: TCP
+service:
+  type: ClusterIP

--- a/docs/documentation/openshell-exporter/helm.md
+++ b/docs/documentation/openshell-exporter/helm.md
@@ -1,93 +1,107 @@
 ---
 title: Deploy with Helm
-description: Install the exporter image on Kubernetes using the upstream OpenTelemetry Collector chart.
+description: Install the exporter on Kubernetes using its own Helm chart from GHCR.
 agent_markdown: true
 ---
 
 # Deploy with Helm
 
-Use the upstream [OpenTelemetry Collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/opentelemetry-collector-0.173.0/charts/opentelemetry-collector)
-with the exporter image and [helm-values.yaml](helm-values.yaml). Research supplies
-configuration; the upstream project maintains the chart. The chart version is
-independent of the exporter image version selected in the values file.
+Use the exporter's `openshell-event-exporter` chart, packaged from its maintained
+`deploy/kubernetes/chart/` directory and distributed through GHCR. The chart
+configures the exporter, credentials, health checks, and persistent storage.
+You do not need access to the source repository.
 
-You need Helm 4, `kubectl`, access to a Kubernetes 1.24+ cluster with a default
-StorageClass, and the gateway/destination credentials described in
-[configuration](configuration.md#connect-a-gateway-and-destination). The cluster
-must reach those endpoints and pull the image. See the [release status](index.md).
-AMD64 and ARM64 Linux nodes use the same image reference; the node's container
-runtime selects the matching manifest. An Apple Silicon development cluster
-running Linux ARM64 nodes uses the ARM64 image.
+You need Helm 3.22+, `kubectl`, Kubernetes 1.29+ with a default StorageClass,
+and an existing HTTPS gateway and CloudEvents destination. The cluster must
+reach both endpoints and pull the image. See the [release status](index.md).
+The published chart pins the matching multi-platform image by digest. Linux
+AMD64 and ARM64 nodes, including Linux ARM64 clusters on Apple Silicon, use the
+same chart and image reference.
 
 ## Prepare
 
-Download the files into your deployment directory:
+Download the small values file into your deployment directory:
 
 ```sh
 export DOCS_URL=https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter
-curl -fL "$DOCS_URL/gateway.yaml" -o config.yaml
+export CHART=oci://ghcr.io/nvidia/charts/openshell-event-exporter
+export VERSION=0.0.5-rc.1
 curl -fL "$DOCS_URL/helm-values.yaml" -o helm-values.yaml
 ```
 
-Edit `extraEnvs` in `helm-values.yaml` to select your gateway, stable identity,
-workspace, authorized sandbox, and HTTPS destination. Adjust storage requests
-and set `spec.storageClassName` in each volume claim if the cluster has no default
-StorageClass. Keep one replica for this gateway collection profile.
+Edit `source` and `destination` in `helm-values.yaml`: set the gateway URL,
+stable gateway identity, workspace, authorized sandbox label selector, and
+CloudEvents URL. An empty selector collects all accessible sandboxes. Adjust
+storage sizes; set `storageClass` under each persistence entry if needed.
+The `stream` profile collects WatchSandbox activity and policy snapshots with
+one exporter replica, durable delivery, and local recovery output.
 
-Create a namespace, a Secret from your existing token files, and the configuration
-ConfigMap. Replace the two token file paths:
+Create the namespace and Secrets from existing raw token and CA certificate
+files. Replace the paths below. Tokens must not include the `Bearer` prefix.
+Use a CA bundle that verifies each endpoint, including its public trust chain
+when applicable:
 
 ```sh
 kubectl create namespace openshell-observability
-kubectl -n openshell-observability create secret generic openshell-exporter-auth \
-  --from-file=gateway-token=/path/to/gateway-token \
-  --from-file=destination-token=/path/to/destination-token
-kubectl -n openshell-observability create configmap openshell-exporter-config \
-  --from-file=relay=config.yaml
+kubectl -n openshell-observability create secret generic openshell-exporter-source-auth \
+  --from-file=token=/path/to/gateway-token
+kubectl -n openshell-observability create secret generic openshell-exporter-source-tls \
+  --from-file=ca.crt=/path/to/gateway-ca.pem
+kubectl -n openshell-observability create secret generic openshell-exporter-destination-auth \
+  --from-file=token=/path/to/destination-token
+kubectl -n openshell-observability create secret generic openshell-exporter-destination-tls \
+  --from-file=ca.crt=/path/to/destination-ca.pem
 ```
 
-The upstream chart expects the configuration key to be named `relay`; this does
-not enable NeMo Relay. For private CAs or mTLS, include the corresponding files in
-the Secret and set `/run/secrets/...` TLS paths in `config.yaml` before creating
-the ConfigMap.
+For mTLS, set `source.mtlsEnabled` or `destination.cloudEvents.mtlsEnabled` to
+`true` and add `--from-file=tls.crt=/path/to/client.crt` and
+`--from-file=tls.key=/path/to/client.key` to that TLS Secret's creation command.
+For a gateway authenticated only by mTLS, also set `source.bearerEnabled: false`
+and omit the source token Secret. Keep TLS verification enabled.
 
 ## Install and verify
 
 ```sh
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-helm repo update open-telemetry
-helm upgrade --install openshell-exporter open-telemetry/opentelemetry-collector \
-  --version 0.173.0 --namespace openshell-observability \
+helm upgrade --install openshell-exporter "$CHART" \
+  --version "$VERSION" --namespace openshell-observability \
   --values helm-values.yaml --wait --timeout 5m
-kubectl -n openshell-observability rollout status statefulset/openshell-exporter
-kubectl -n openshell-observability logs openshell-exporter-0 --tail=30
+kubectl -n openshell-observability rollout status deployment/openshell-exporter
+kubectl -n openshell-observability logs deployment/openshell-exporter -c exporter --tail=30
 kubectl -n openshell-observability port-forward service/openshell-exporter 23133:13133
 ```
 
 In another terminal, run `curl --fail http://127.0.0.1:23133/`. Generate authorized
-sandbox activity and confirm CloudEvents arrive at your destination. Port
-forwarding checks health; it does not prove delivery. The deployment uses separate
-persistent claims for state and recovery, runs non-root, and mounts no Kubernetes
-API token. It does not install a gateway or cluster-wide log collection.
+sandbox activity and confirm CloudEvents arrive at your destination. Health
+alone does not prove delivery. The chart creates separate queue, recovery, and
+checkpoint PVCs, runs non-root, and uses no Kubernetes API token in this profile.
+Recovery records append to `/var/lib/openshell-exporter/recovery/openshell-events.json`.
+Monitor storage usage and arrange retention; delivery can retry, so destinations
+must deduplicate by `(source,id)`.
 
-## Update or remove
+## Configure, update, or remove
 
-After editing configuration, update the ConfigMap and restart the workload:
+The chart generates Collector configuration from its values. Inspect the full
+settings, including the `complete` and `custom` profiles for additional components:
 
 ```sh
-kubectl -n openshell-observability create configmap openshell-exporter-config \
-  --from-file=relay=config.yaml --dry-run=client -o yaml | kubectl apply -f -
-kubectl -n openshell-observability rollout restart statefulset/openshell-exporter
-kubectl -n openshell-observability rollout status statefulset/openshell-exporter
+helm show values "$CHART" --version "$VERSION" > chart-defaults.yaml
 ```
 
-For an image upgrade, change `image.tag` or `image.digest` in the values file and
-repeat `helm upgrade --install`. Keep the previous image and configuration for
-rollback. To remove the workload:
+Keep your overrides in `helm-values.yaml`. Repeat the install command after
+editing values; change `VERSION` to a reviewed chart release when upgrading.
+After rotating Secret contents, restart the exporter to reload credentials:
+
+```sh
+kubectl -n openshell-observability rollout restart deployment/openshell-exporter
+kubectl -n openshell-observability rollout status deployment/openshell-exporter
+```
+
+To remove the workload:
 
 ```sh
 helm uninstall openshell-exporter --namespace openshell-observability
 ```
 
-The ConfigMap, Secret, namespace, and StatefulSet PVCs remain. Preserve the PVCs
-for reinstall/recovery; removing the namespace also removes these resources.
+The chart retains its PVCs; the manually created Secrets and namespace remain.
+Preserve them for reinstall/recovery. Deleting the namespace also deletes these
+resources. This profile does not install a gateway or collect cluster-wide files.

--- a/docs/documentation/openshell-exporter/helm.md
+++ b/docs/documentation/openshell-exporter/helm.md
@@ -1,0 +1,93 @@
+---
+title: Deploy with Helm
+description: Install the exporter image on Kubernetes using the upstream OpenTelemetry Collector chart.
+agent_markdown: true
+---
+
+# Deploy with Helm
+
+Use the upstream [OpenTelemetry Collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/opentelemetry-collector-0.173.0/charts/opentelemetry-collector)
+with the exporter image and [helm-values.yaml](helm-values.yaml). Research supplies
+configuration; the upstream project maintains the chart. The chart version is
+independent of the exporter image version selected in the values file.
+
+You need Helm 4, `kubectl`, access to a Kubernetes 1.24+ cluster with a default
+StorageClass, and the gateway/destination credentials described in
+[configuration](configuration.md#connect-a-gateway-and-destination). The cluster
+must reach those endpoints and pull the image. See the [release status](index.md).
+AMD64 and ARM64 Linux nodes use the same image reference; the node's container
+runtime selects the matching manifest. An Apple Silicon development cluster
+running Linux ARM64 nodes uses the ARM64 image.
+
+## Prepare
+
+Download the files into your deployment directory:
+
+```sh
+export DOCS_URL=https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter
+curl -fL "$DOCS_URL/gateway.yaml" -o config.yaml
+curl -fL "$DOCS_URL/helm-values.yaml" -o helm-values.yaml
+```
+
+Edit `extraEnvs` in `helm-values.yaml` to select your gateway, stable identity,
+workspace, authorized sandbox, and HTTPS destination. Adjust storage requests
+and set `spec.storageClassName` in each volume claim if the cluster has no default
+StorageClass. Keep one replica for this gateway collection profile.
+
+Create a namespace, a Secret from your existing token files, and the configuration
+ConfigMap. Replace the two token file paths:
+
+```sh
+kubectl create namespace openshell-observability
+kubectl -n openshell-observability create secret generic openshell-exporter-auth \
+  --from-file=gateway-token=/path/to/gateway-token \
+  --from-file=destination-token=/path/to/destination-token
+kubectl -n openshell-observability create configmap openshell-exporter-config \
+  --from-file=relay=config.yaml
+```
+
+The upstream chart expects the configuration key to be named `relay`; this does
+not enable NeMo Relay. For private CAs or mTLS, include the corresponding files in
+the Secret and set `/run/secrets/...` TLS paths in `config.yaml` before creating
+the ConfigMap.
+
+## Install and verify
+
+```sh
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update open-telemetry
+helm upgrade --install openshell-exporter open-telemetry/opentelemetry-collector \
+  --version 0.173.0 --namespace openshell-observability \
+  --values helm-values.yaml --wait --timeout 5m
+kubectl -n openshell-observability rollout status statefulset/openshell-exporter
+kubectl -n openshell-observability logs openshell-exporter-0 --tail=30
+kubectl -n openshell-observability port-forward service/openshell-exporter 23133:13133
+```
+
+In another terminal, run `curl --fail http://127.0.0.1:23133/`. Generate authorized
+sandbox activity and confirm CloudEvents arrive at your destination. Port
+forwarding checks health; it does not prove delivery. The deployment uses separate
+persistent claims for state and recovery, runs non-root, and mounts no Kubernetes
+API token. It does not install a gateway or cluster-wide log collection.
+
+## Update or remove
+
+After editing configuration, update the ConfigMap and restart the workload:
+
+```sh
+kubectl -n openshell-observability create configmap openshell-exporter-config \
+  --from-file=relay=config.yaml --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n openshell-observability rollout restart statefulset/openshell-exporter
+kubectl -n openshell-observability rollout status statefulset/openshell-exporter
+```
+
+For an image upgrade, change `image.tag` or `image.digest` in the values file and
+repeat `helm upgrade --install`. Keep the previous image and configuration for
+rollback. To remove the workload:
+
+```sh
+helm uninstall openshell-exporter --namespace openshell-observability
+```
+
+The ConfigMap, Secret, namespace, and StatefulSet PVCs remain. Preserve the PVCs
+for reinstall/recovery; removing the namespace also removes these resources.

--- a/docs/documentation/openshell-exporter/index.md
+++ b/docs/documentation/openshell-exporter/index.md
@@ -1,186 +1,86 @@
 ---
-title: OpenShell Event Exporter
-description: Install the container image, collect OpenShell evidence, and configure delivery.
+title: Export OpenShell evidence
+description: Collect OpenShell evidence with a prebuilt image. Start locally, then deploy with Docker, Podman, or Helm.
 agent_markdown: true
 ---
 
-# OpenShell Event Exporter
+# Export OpenShell evidence
 
-Collect OpenShell security records, sandbox activity, policy snapshots, and agent
-traces. The exporter normalizes and redacts evidence, preserves stable event
-identity, and delivers CloudEvents over HTTPS or native OTLP.
+OpenShell Event Exporter collects security records, sandbox activity, policy
+snapshots, and agent traces. It normalizes and redacts evidence, then sends it to
+your security or observability tools as CloudEvents or OTLP.
 
-Experimental research tool, provided as-is. Use at your own risk.
+Use a prebuilt image from GHCR. You do not need Go, a source checkout, or an
+image build. This is an experimental research tool, provided as-is. Use at your
+own risk.
 
-> Release candidate: the image names below are reserved for `v0.0.5-rc.1`.
-> Public image publication and anonymous-pull verification are pending.
+Each release image targets Linux AMD64 and ARM64. Docker Desktop on Apple Silicon
+Macs runs the Linux ARM64 image in its VM; Intel Macs use Linux AMD64. The same
+image reference selects the matching architecture automatically.
 
-## Install and try it
+> **Release pending:** the `v0.0.5-rc.1` image references in these guides are
+> awaiting public publication and anonymous-pull verification.
 
-You need Docker on Linux, or Docker Desktop, and `curl`. Images are distributed
-through GitHub Container Registry (GHCR); no source checkout or Go installation
-is required. Run these commands in a Bash-compatible shell:
+## Choose your deployment
 
-```sh
-mkdir openshell-exporter
-cd openshell-exporter
-mkdir input state output
-chmod 700 state output
-curl --fail --location --output config.yaml \
-  https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter/config.yaml
-export EXPORTER_IMAGE=ghcr.io/nvidia/openshell-exporter:v0.0.5-rc.1
-docker pull "$EXPORTER_IMAGE"
-docker run --rm "$EXPORTER_IMAGE" --version
-docker run --rm --user "$(id -u):$(id -g)" \
-  --mount "type=bind,src=$PWD/config.yaml,dst=/etc/exporter.yaml,readonly" \
-  "$EXPORTER_IMAGE" validate --config /etc/exporter.yaml
-```
+| Deployment | Start here |
+| --- | --- |
+| Docker / Docker Desktop | Try the quickstart below, then [manage the Compose deployment](docker.md). |
+| Rootless Podman on Linux | [Run the same image with Podman](podman.md). |
+| Kubernetes with Helm | [Install with the OpenTelemetry Helm chart](helm.md). |
 
-The [starter configuration](config.yaml) reads OCSF JSONL files from `input/` and
-writes normalized, redacted Collector JSON to `output/events.json`. It needs no
-gateway or inference credentials. Start it:
+## Quickstart with Docker
+
+You need Docker with Compose v2 (Linux AMD64/ARM64, or Docker Desktop on Intel or
+Apple Silicon macOS), `curl`, and a Bash-compatible shell. Keep local
+port `23133` free. This first run reads a local JSONL file; it needs no gateway or
+inference credentials.
+
+Download the configuration and Compose file into an empty working directory:
 
 ```sh
-docker run -d --name openshell-exporter \
-  --user "$(id -u):$(id -g)" --read-only --tmpfs /tmp \
-  --cap-drop ALL --security-opt no-new-privileges --memory 512m \
-  -p 127.0.0.1:23133:13133 \
-  --mount "type=bind,src=$PWD/config.yaml,dst=/etc/exporter.yaml,readonly" \
-  --mount "type=bind,src=$PWD/input,dst=/input,readonly" \
-  --mount "type=bind,src=$PWD/state,dst=/state" \
-  --mount "type=bind,src=$PWD/output,dst=/output" \
-  "$EXPORTER_IMAGE" --config /etc/exporter.yaml
-curl --fail --retry 10 --retry-all-errors --retry-delay 1 http://127.0.0.1:23133/
+mkdir openshell-exporter && cd openshell-exporter
+mkdir input state output secrets
+chmod 700 state output secrets
+export DOCS_URL=https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter
+curl -fL "$DOCS_URL/config.yaml" -o config.yaml
+curl -fL "$DOCS_URL/compose.yaml" -o compose.yaml
+printf 'EXPORTER_UID=%s\nEXPORTER_GID=%s\n' "$(id -u)" "$(id -g)" > .env
+docker compose run --rm exporter validate --config /etc/exporter.yaml
+docker compose up -d --wait
 ```
 
-Copy authorized OpenShell OCSF files into `input/` with a `.jsonl` suffix. To test
-without real records, append this explicitly synthetic event:
+Append a synthetic record and inspect the normalized output:
 
 ```sh
 printf '%s\n' '{"class_uid":4001,"activity_id":1,"time":1789084800000,"severity_id":1,"message":"synthetic quickstart event"}' >> input/sample.jsonl
 sleep 2
 cat output/events.json
-docker logs --tail 20 openshell-exporter
+curl --fail http://127.0.0.1:23133/
 ```
 
-The sample demonstrates collection; it is not gateway evidence. Malformed or
-incomplete records are marked, not silently dropped. Health indicates the process
-is running; confirm records arrive at the intended destination to verify delivery.
+`output/events.json` should contain the sample message inside a normalized event.
+The sample tests collection; it is not real gateway evidence. Incomplete records
+are marked rather than dropped. Health alone does not prove delivery.
 
-Stop with `docker stop openshell-exporter`. Resume with `docker start
-openshell-exporter`. To change configuration, stop and remove the container with
-`docker rm openshell-exporter`, then rerun the start command. Keep `input/`,
-`state/`, and `output/`: deleting them can lose evidence or replay checkpoints.
+Stop with `docker compose stop`; resume with `docker compose start`. Your input,
+checkpoints, and output stay in this directory. Do not delete `state/` to fix a
+startup problem.
 
-## Configure sources
+## Connect your environment
 
-Edit `config.yaml`, validate it, then recreate the container. Keep `gateway_id`,
-`workspace`, and `source_instance` stable and unique to the source. The
-`source_profiles` list describes enabled inputs; it does not create receivers.
+[Configure sources and delivery](configuration.md) to collect existing OCSF files
+or connect a gateway to an HTTPS CloudEvents destination. The deployment guides
+use the same Collector configuration and persistent storage layout.
 
-For an existing gateway, add this entry under `receivers` and replace the endpoint,
-workspace, gateway ID, and sandbox names with your authorized scope:
+The image also includes Relay privacy processing, native OTLP, file forwarding,
+and edge/central components. Enable only the components you need. The optional
+OTLP proxy has its own image; it is not required for the quickstart.
 
-```yaml
-  watchsandbox:
-    endpoint: https://gateway.example.com:8080
-    gateway_id: gateway-1
-    workspace: default
-    sandbox_names: [my-sandbox]
-    token_env: ""
-    token_file: /run/secrets/gateway-token
-    tls:
-      ca_file: /run/secrets/gateway-ca.pem
-    policy_reconciliation:
-      enabled: true
-      storage: file_storage/checkpoints
-      include_effective_policies: false
-```
+WatchSandbox cannot resume missed stream history. Policy reads are snapshots,
+and redaction is not DLP. Treat exported evidence as sensitive and deduplicate
+CloudEvents by `(source,id)`.
 
-Use read-only gateway credentials. Add read-only bind mounts for the token and
-CA files to both validation and startup commands. For mTLS, also mount the client
-certificate and key and set `tls.cert_file` and `tls.key_file`. Configure the
-processor with the same gateway/workspace and
-`source_profiles: [ocsf.file, watchsandbox, policy.reconciliation]`; change the
-logs pipeline receivers to `[file_log/ocsf, watchsandbox]`. Remove the file receiver
-and its profile if you only want gateway streams.
-
-WatchSandbox cannot resume a disconnected stream. Policy reconciliation reads
-snapshots; it does not reconstruct all missed history. Retain OCSF files until
-read, preserve their paths across restarts, and collect each file through one
-writer only.
-
-## Send CloudEvents over HTTPS
-
-Add these entries under `extensions`:
-
-```yaml
-  bearertokenauth/destination:
-    filename: /run/secrets/destination-token
-  file_storage/cloudevents_queue:
-    directory: /state/cloudevents-queue
-    create_directory: true
-```
-
-Add a destination under `exporters`, using your receiver's HTTPS URL:
-
-```yaml
-  cloudevents:
-    endpoint: https://receiver.example.com/v1/events
-    auth:
-      authenticator: bearertokenauth/destination
-    retry_on_failure:
-      enabled: true
-      max_elapsed_time: 0s
-    sending_queue:
-      enabled: true
-      storage: file_storage/cloudevents_queue
-      queue_size: 10000
-      num_consumers: 4
-      block_on_overflow: true
-```
-
-Mount the destination token file read-only. For a private CA, add `tls.ca_file`
-and mount that CA too. Add `bearertokenauth/destination` and
-`file_storage/cloudevents_queue` to `service.extensions`, then set the logs
-pipeline exporters to `[cloudevents, file/recovery]`. Add
-`cloudevents_queue: /state/cloudevents-queue` to `storagehealth.paths`.
-
-The endpoint must accept CloudEvents HTTP JSON batches and deduplicate by
-`(source,id)`. Delivery can be retried; it is not exactly once. Preserve separate
-checkpoint, queue, and recovery paths. Do not share writable state between
-exporters. Restrict access to recovery files and monitor disk capacity.
-
-## Other components and deployments
-
-The exporter image also includes Relay privacy processing, native OTLP receivers
-and exporters, file forwarding, and edge/central evidence processing. Inspect its
-installed components with:
-
-```sh
-docker run --rm "$EXPORTER_IMAGE" components
-```
-
-Keep Relay and native gateway OTLP in separate pipelines. Relay traces require
-`relay` processing with `privacy.mode: allow` before delivery. Use authenticated
-TLS inputs, a separate destination credential, and persistent queues. Redaction
-is not DLP; exported evidence still needs access controls.
-
-An optional workload-local trace proxy is distributed as
-`ghcr.io/nvidia/openshell-otlp-proxy:v0.0.5-rc.1`. It forwards OTLP/HTTP with a
-persistent queue and does not apply the exporter's privacy filtering. Deploy it
-only when that extra queue is needed; its storage can contain unfiltered data.
-
-Docker, Podman, and Kubernetes can pull the same images. For Kubernetes, use the
-image in your Deployment, mount Collector configuration through a ConfigMap,
-credentials through Secrets, and state/output through persistent volumes. Run
-non-root, disable service-account token mounting, and keep health and telemetry
-ports private. Use one replica per writable state volume. No image build inside
-the cluster is required.
-
-Pin an image version or digest, retain state, and validate configuration before
-upgrading. The images include the project's Apache-2.0 license and notices at
-`/usr/share/licenses/openshell-exporter/`, with Go and third-party licenses
-alongside them under `/usr/share/licenses/`. Report issues through
-[OpenShell Research](https://github.com/NVIDIA/OpenShell-Research/issues), including
-the image digest and sanitized configuration; never include tokens or raw evidence.
+[Report an issue](https://github.com/NVIDIA/OpenShell-Research/issues) with the
+image version and sanitized configuration. Licenses and notices are included
+under `/usr/share/licenses/` in the images.

--- a/docs/documentation/openshell-exporter/index.md
+++ b/docs/documentation/openshell-exporter/index.md
@@ -18,7 +18,7 @@ Each release image targets Linux AMD64 and ARM64. Docker Desktop on Apple Silico
 Macs runs the Linux ARM64 image in its VM; Intel Macs use Linux AMD64. The same
 image reference selects the matching architecture automatically.
 
-> **Release pending:** the `v0.0.5-rc.1` image references in these guides are
+> **Release pending:** the `v0.0.5-rc.1` images and `0.0.5-rc.1` Helm chart are
 > awaiting public publication and anonymous-pull verification.
 
 ## Choose your deployment
@@ -27,7 +27,7 @@ image reference selects the matching architecture automatically.
 | --- | --- |
 | Docker / Docker Desktop | Try the quickstart below, then [manage the Compose deployment](docker.md). |
 | Rootless Podman on Linux | [Run the same image with Podman](podman.md). |
-| Kubernetes with Helm | [Install with the OpenTelemetry Helm chart](helm.md). |
+| Kubernetes with Helm | [Install with the exporter Helm chart](helm.md). |
 
 ## Quickstart with Docker
 

--- a/docs/documentation/openshell-exporter/index.md
+++ b/docs/documentation/openshell-exporter/index.md
@@ -1,0 +1,186 @@
+---
+title: OpenShell Event Exporter
+description: Install the container image, collect OpenShell evidence, and configure delivery.
+agent_markdown: true
+---
+
+# OpenShell Event Exporter
+
+Collect OpenShell security records, sandbox activity, policy snapshots, and agent
+traces. The exporter normalizes and redacts evidence, preserves stable event
+identity, and delivers CloudEvents over HTTPS or native OTLP.
+
+Experimental research tool, provided as-is. Use at your own risk.
+
+> Release candidate: the image names below are reserved for `v0.0.5-rc.1`.
+> Public image publication and anonymous-pull verification are pending.
+
+## Install and try it
+
+You need Docker on Linux, or Docker Desktop, and `curl`. Images are distributed
+through GitHub Container Registry (GHCR); no source checkout or Go installation
+is required. Run these commands in a Bash-compatible shell:
+
+```sh
+mkdir openshell-exporter
+cd openshell-exporter
+mkdir input state output
+chmod 700 state output
+curl --fail --location --output config.yaml \
+  https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter/config.yaml
+export EXPORTER_IMAGE=ghcr.io/nvidia/openshell-exporter:v0.0.5-rc.1
+docker pull "$EXPORTER_IMAGE"
+docker run --rm "$EXPORTER_IMAGE" --version
+docker run --rm --user "$(id -u):$(id -g)" \
+  --mount "type=bind,src=$PWD/config.yaml,dst=/etc/exporter.yaml,readonly" \
+  "$EXPORTER_IMAGE" validate --config /etc/exporter.yaml
+```
+
+The [starter configuration](config.yaml) reads OCSF JSONL files from `input/` and
+writes normalized, redacted Collector JSON to `output/events.json`. It needs no
+gateway or inference credentials. Start it:
+
+```sh
+docker run -d --name openshell-exporter \
+  --user "$(id -u):$(id -g)" --read-only --tmpfs /tmp \
+  --cap-drop ALL --security-opt no-new-privileges --memory 512m \
+  -p 127.0.0.1:23133:13133 \
+  --mount "type=bind,src=$PWD/config.yaml,dst=/etc/exporter.yaml,readonly" \
+  --mount "type=bind,src=$PWD/input,dst=/input,readonly" \
+  --mount "type=bind,src=$PWD/state,dst=/state" \
+  --mount "type=bind,src=$PWD/output,dst=/output" \
+  "$EXPORTER_IMAGE" --config /etc/exporter.yaml
+curl --fail --retry 10 --retry-all-errors --retry-delay 1 http://127.0.0.1:23133/
+```
+
+Copy authorized OpenShell OCSF files into `input/` with a `.jsonl` suffix. To test
+without real records, append this explicitly synthetic event:
+
+```sh
+printf '%s\n' '{"class_uid":4001,"activity_id":1,"time":1789084800000,"severity_id":1,"message":"synthetic quickstart event"}' >> input/sample.jsonl
+sleep 2
+cat output/events.json
+docker logs --tail 20 openshell-exporter
+```
+
+The sample demonstrates collection; it is not gateway evidence. Malformed or
+incomplete records are marked, not silently dropped. Health indicates the process
+is running; confirm records arrive at the intended destination to verify delivery.
+
+Stop with `docker stop openshell-exporter`. Resume with `docker start
+openshell-exporter`. To change configuration, stop and remove the container with
+`docker rm openshell-exporter`, then rerun the start command. Keep `input/`,
+`state/`, and `output/`: deleting them can lose evidence or replay checkpoints.
+
+## Configure sources
+
+Edit `config.yaml`, validate it, then recreate the container. Keep `gateway_id`,
+`workspace`, and `source_instance` stable and unique to the source. The
+`source_profiles` list describes enabled inputs; it does not create receivers.
+
+For an existing gateway, add this entry under `receivers` and replace the endpoint,
+workspace, gateway ID, and sandbox names with your authorized scope:
+
+```yaml
+  watchsandbox:
+    endpoint: https://gateway.example.com:8080
+    gateway_id: gateway-1
+    workspace: default
+    sandbox_names: [my-sandbox]
+    token_env: ""
+    token_file: /run/secrets/gateway-token
+    tls:
+      ca_file: /run/secrets/gateway-ca.pem
+    policy_reconciliation:
+      enabled: true
+      storage: file_storage/checkpoints
+      include_effective_policies: false
+```
+
+Use read-only gateway credentials. Add read-only bind mounts for the token and
+CA files to both validation and startup commands. For mTLS, also mount the client
+certificate and key and set `tls.cert_file` and `tls.key_file`. Configure the
+processor with the same gateway/workspace and
+`source_profiles: [ocsf.file, watchsandbox, policy.reconciliation]`; change the
+logs pipeline receivers to `[file_log/ocsf, watchsandbox]`. Remove the file receiver
+and its profile if you only want gateway streams.
+
+WatchSandbox cannot resume a disconnected stream. Policy reconciliation reads
+snapshots; it does not reconstruct all missed history. Retain OCSF files until
+read, preserve their paths across restarts, and collect each file through one
+writer only.
+
+## Send CloudEvents over HTTPS
+
+Add these entries under `extensions`:
+
+```yaml
+  bearertokenauth/destination:
+    filename: /run/secrets/destination-token
+  file_storage/cloudevents_queue:
+    directory: /state/cloudevents-queue
+    create_directory: true
+```
+
+Add a destination under `exporters`, using your receiver's HTTPS URL:
+
+```yaml
+  cloudevents:
+    endpoint: https://receiver.example.com/v1/events
+    auth:
+      authenticator: bearertokenauth/destination
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+    sending_queue:
+      enabled: true
+      storage: file_storage/cloudevents_queue
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+```
+
+Mount the destination token file read-only. For a private CA, add `tls.ca_file`
+and mount that CA too. Add `bearertokenauth/destination` and
+`file_storage/cloudevents_queue` to `service.extensions`, then set the logs
+pipeline exporters to `[cloudevents, file/recovery]`. Add
+`cloudevents_queue: /state/cloudevents-queue` to `storagehealth.paths`.
+
+The endpoint must accept CloudEvents HTTP JSON batches and deduplicate by
+`(source,id)`. Delivery can be retried; it is not exactly once. Preserve separate
+checkpoint, queue, and recovery paths. Do not share writable state between
+exporters. Restrict access to recovery files and monitor disk capacity.
+
+## Other components and deployments
+
+The exporter image also includes Relay privacy processing, native OTLP receivers
+and exporters, file forwarding, and edge/central evidence processing. Inspect its
+installed components with:
+
+```sh
+docker run --rm "$EXPORTER_IMAGE" components
+```
+
+Keep Relay and native gateway OTLP in separate pipelines. Relay traces require
+`relay` processing with `privacy.mode: allow` before delivery. Use authenticated
+TLS inputs, a separate destination credential, and persistent queues. Redaction
+is not DLP; exported evidence still needs access controls.
+
+An optional workload-local trace proxy is distributed as
+`ghcr.io/nvidia/openshell-otlp-proxy:v0.0.5-rc.1`. It forwards OTLP/HTTP with a
+persistent queue and does not apply the exporter's privacy filtering. Deploy it
+only when that extra queue is needed; its storage can contain unfiltered data.
+
+Docker, Podman, and Kubernetes can pull the same images. For Kubernetes, use the
+image in your Deployment, mount Collector configuration through a ConfigMap,
+credentials through Secrets, and state/output through persistent volumes. Run
+non-root, disable service-account token mounting, and keep health and telemetry
+ports private. Use one replica per writable state volume. No image build inside
+the cluster is required.
+
+Pin an image version or digest, retain state, and validate configuration before
+upgrading. The images include the project's Apache-2.0 license and notices at
+`/usr/share/licenses/openshell-exporter/`, with Go and third-party licenses
+alongside them under `/usr/share/licenses/`. Report issues through
+[OpenShell Research](https://github.com/NVIDIA/OpenShell-Research/issues), including
+the image digest and sanitized configuration; never include tokens or raw evidence.

--- a/docs/documentation/openshell-exporter/podman.md
+++ b/docs/documentation/openshell-exporter/podman.md
@@ -1,0 +1,71 @@
+---
+title: Deploy with Podman
+description: Run the exporter rootlessly on Linux with persistent local directories.
+agent_markdown: true
+---
+
+# Deploy with Podman
+
+You need rootless Podman on Linux AMD64 or ARM64, `curl`, and a Bash-compatible shell. No Compose
+provider is required. The [release status](index.md) applies to these image
+commands. Keep local port `23133` free.
+
+On macOS, Podman runs Linux containers through Podman Machine; Apple Silicon uses
+the ARM64 image. The commands below target a Linux host. For a Mac quickstart,
+use the [Docker Desktop path](index.md#quickstart-with-docker).
+
+## Prepare
+
+```sh
+mkdir openshell-exporter && cd openshell-exporter
+mkdir input state output secrets
+chmod 700 state output secrets
+export DOCS_URL=https://nvidia.github.io/OpenShell-Research/documentation/openshell-exporter
+curl -fL "$DOCS_URL/config.yaml" -o config.yaml
+export EXPORTER_IMAGE=ghcr.io/nvidia/openshell-exporter:v0.0.5-rc.1
+podman pull "$EXPORTER_IMAGE"
+podman run --rm --userns=keep-id --user "$(id -u):$(id -g)" \
+  -v "$PWD/config.yaml:/etc/exporter.yaml:ro,Z" \
+  "$EXPORTER_IMAGE" validate --config /etc/exporter.yaml
+```
+
+The [starter configuration](config.yaml) reads `input/*.jsonl` and appends
+normalized records to `output/events.json`. For a gateway and HTTPS destination,
+follow [configuration](configuration.md) first; save the non-secret settings in
+`.env` and add `--env-file .env` to validation and startup. Validation for that
+profile also needs `-v "$PWD/secrets:/run/secrets:ro,Z"`.
+
+## Start and verify
+
+```sh
+podman run -d --name openshell-exporter \
+  --userns=keep-id --user "$(id -u):$(id -g)" \
+  --read-only --tmpfs /tmp:rw,noexec,nosuid,size=16m \
+  --cap-drop ALL --security-opt no-new-privileges --memory 512m \
+  -p 127.0.0.1:23133:13133 \
+  -v "$PWD/config.yaml:/etc/exporter.yaml:ro,Z" \
+  -v "$PWD/input:/input:ro,Z" \
+  -v "$PWD/state:/state:Z" \
+  -v "$PWD/output:/output:Z" \
+  -v "$PWD/secrets:/run/secrets:ro,Z" \
+  "$EXPORTER_IMAGE" --config /etc/exporter.yaml
+curl --fail --retry 10 --retry-all-errors --retry-delay 1 http://127.0.0.1:23133/
+```
+
+Copy authorized OCSF JSONL files into `input/`, or append the synthetic record from
+the [quickstart](index.md#quickstart-with-docker). Check `output/events.json` and
+`podman logs --tail 30 openshell-exporter`. The `:Z` options label only these
+working-directory mounts for SELinux; `keep-id` preserves write access for your
+host user. See [Podman's volume and user-namespace options](https://docs.podman.io/en/latest/markdown/podman-run.1.html).
+
+## Stop or change configuration
+
+```sh
+podman stop openshell-exporter
+podman start openshell-exporter
+```
+
+To change configuration or image version, stop and remove the container with
+`podman rm openshell-exporter`, then validate and repeat the start command.
+Keep `state/` and `output/`; deleting either can lose replay state or recovery
+records. Restore `EXPORTER_IMAGE` in a new shell before recreating the container.

--- a/docs/documentation/openshell-exporter/template.config.yaml
+++ b/docs/documentation/openshell-exporter/template.config.yaml
@@ -1,0 +1,651 @@
+# OpenShell Event Exporter v0.0.5-rc.1 / Collector v0.160.0
+# Configuration reference: every exporter-owned setting and examples for all
+# component types included in the exporter image. Advanced upstream transport
+# and parser settings are outside this reference. Values are examples, not a
+# statement of defaults. Start with config.yaml for the short runnable example.
+#
+# Before use: select inputs/pipelines, replace identities, paths and endpoints,
+# mount required token/CA/client-certificate files under /run/secrets, and mount
+# /input read-only plus separate persistent /state and /output directories.
+# Secrets are raw tokens without the Bearer prefix. Never commit real secrets.
+# Only logs/files is enabled below. Remove unused component definitions before
+# deploying; Collector validation can check unused definitions and secret files.
+# Preserve stable source identity and one writer per checkpoint/queue directory.
+# Keep health/metrics private. Do not publish OTLP ports without authorized TLS
+# clients and the corresponding input credentials/network restrictions.
+
+extensions:
+  bearertokenauth/destination:
+    filename: /run/secrets/destination-token
+  bearertokenauth/nemo_relay:
+    filename: /run/secrets/relay-token
+  bearertokenauth/forwarded_ocsf:
+    filename: /run/secrets/forwarded-token
+  bearertokenauth/otlp_destination:
+    filename: /run/secrets/otlp-destination-token
+  file_storage/checkpoints:
+    directory: /state/checkpoints
+    create_directory: true
+  file_storage/cloudevents_queue:
+    directory: /state/cloudevents-queue
+    create_directory: true
+  file_storage/otlp_queue:
+    directory: /state/otlp-grpc-queue
+    create_directory: true
+  file_storage/otlphttp_queue:
+    directory: /state/otlp-http-queue
+    create_directory: true
+  # All storagehealth settings; only these five path labels are supported.
+  # interval >= 1s; max_entries: 1..10000. Enable in service.extensions only
+  # after provisioning all listed paths, or remove paths for unused exporters.
+  storagehealth:
+    interval: 30s
+    max_entries: 1024
+    paths:
+      checkpoints: /state/checkpoints
+      cloudevents_queue: /state/cloudevents-queue
+      otlp_grpc_queue: /state/otlp-grpc-queue
+      otlp_http_queue: /state/otlp-http-queue
+      recovery: /output/events.json
+  health_check:
+    endpoint: 0.0.0.0:13133
+  file_storage/internal_queue:
+    directory: /state/internal-queue
+    create_directory: true
+  bearertokenauth/internal:
+    filename: /run/secrets/internal-token
+receivers:
+  otlp/nemo_relay:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        auth:
+          authenticator: bearertokenauth/nemo_relay
+        tls:
+          cert_file: /run/secrets/relay.crt
+          key_file: /run/secrets/relay.key
+          client_ca_file: /run/secrets/relay-ca.pem
+      http:
+        endpoint: 0.0.0.0:4318
+        auth:
+          authenticator: bearertokenauth/nemo_relay
+        tls:
+          cert_file: /run/secrets/relay.crt
+          key_file: /run/secrets/relay.key
+          client_ca_file: /run/secrets/relay-ca.pem
+  otlp/openshell_native:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4319
+        tls:
+          cert_file: /run/secrets/native.crt
+          key_file: /run/secrets/native.key
+          reload_interval: 1m
+  otlp/forwarded_ocsf:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4320
+        auth:
+          authenticator: bearertokenauth/forwarded_ocsf
+        tls:
+          cert_file: /run/secrets/forwarded.crt
+          key_file: /run/secrets/forwarded.key
+          reload_interval: 1m
+          client_ca_file_reload: true
+          client_ca_file: /run/secrets/forwarded-ca.pem
+  file_log/openshell_ocsf:
+    include:
+    - /input/sandboxes/*/openshell-ocsf.*.log
+    start_at: beginning
+    storage: file_storage/checkpoints
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 0s
+    include_file_path: true
+    include_file_path_resolved: true
+    include_file_record_offset: true
+    include_file_record_number: true
+    on_truncate: read_whole_file
+    max_log_size: 8MiB
+    max_log_size_behavior: split
+    attributes:
+      openshell.acquisition.kind: ocsf.file
+      openshell.acquisition.source_instance: sandbox-ocsf-jsonl
+    operators:
+    - type: json_parser
+      parse_from: body
+      parse_to: body
+      on_error: send
+  file_log/openshell_sandbox:
+    include:
+    - /input/sandboxes/*/openshell.*.log
+    start_at: beginning
+    storage: file_storage/checkpoints
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 0s
+    include_file_path: true
+    include_file_path_resolved: true
+    include_file_record_offset: true
+    include_file_record_number: true
+    on_truncate: read_whole_file
+    max_log_size: 8MiB
+    max_log_size_behavior: split
+    attributes:
+      openshell.acquisition.kind: sandbox.file_log
+      openshell.acquisition.source_instance: sandbox-operational-log
+  file_log/nemo_relay:
+    include:
+    - /input/relay/*.jsonl
+    start_at: beginning
+    storage: file_storage/checkpoints
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 0s
+    include_file_path: true
+    include_file_path_resolved: true
+    include_file_record_offset: true
+    include_file_record_number: true
+    on_truncate: read_whole_file
+    max_log_size: 8MiB
+    max_log_size_behavior: split
+    attributes:
+      openshell.acquisition.kind: nemo_relay.log
+      openshell.acquisition.source_instance: nemo-relay-file
+    operators:
+    - type: json_parser
+      parse_from: body
+      parse_to: body
+      on_error: send
+  # All WatchSandbox settings. sandbox_names selects explicit names; an empty
+  # list uses discovery with label_selector. Use read-only source credentials.
+  # token_env is an alternative to token_file; never set both. For mTLS set
+  # both cert_file/key_file. insecure_skip_verify must stay false (true rejected).
+  # Reconciliation workers: 1..16, queue_size: 1..10000, max_revisions: 1..100000.
+  # Effective policy bodies are opt-in; snapshots cannot reconstruct stream gaps.
+  watchsandbox:
+    endpoint: https://gateway.example.com:8080
+    allow_insecure_http: false
+    workspace: default
+    gateway_id: gateway-1
+    label_selector: observability=enabled
+    discovery_interval: 30s
+    token_env: ''
+    token_file: /run/secrets/gateway-token
+    log_tail_lines: 200
+    event_tail: 200
+    reconnect_initial: 1s
+    reconnect_max: 30s
+    policy_reconciliation:
+      enabled: true
+      interval: 5m
+      timeout: 15s
+      workers: 2
+      queue_size: 128
+      max_revisions: 10000
+      include_history: true
+      include_effective_policies: false
+      storage: file_storage/checkpoints
+    tls:
+      ca_file: /run/secrets/gateway-ca.pem
+      cert_file: ''
+      key_file: ''
+      insecure_skip_verify: false
+    sandbox_names: []
+  # Optional Kubernetes context: provision namespace-scoped list/watch RBAC
+  # and a service account token. The Docker/Podman starter does not provide it.
+  k8s_objects:
+    auth_type: serviceAccount
+    storage: file_storage/checkpoints
+    error_mode: propagate
+    include_initial_state: true
+    objects:
+    - name: pods
+      mode: watch
+      namespaces:
+      - sandbox-namespace
+    - name: events
+      group: events.k8s.io
+      mode: watch
+      namespaces:
+      - sandbox-namespace
+  otlp/internal:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4330
+        auth:
+          authenticator: bearertokenauth/internal
+        tls:
+          cert_file: /run/secrets/central.crt
+          key_file: /run/secrets/central.key
+          client_ca_file: /run/secrets/internal-ca.pem
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+    spike_limit_mib: 128
+  # All normalizer settings. source_profiles declares expected evidence types;
+  # it does not enable receivers. validation.mode only supports mark.
+  # Redaction arrays replace defaults: retain the built-in protections when
+  # adding patterns. Identity is calculated before redaction.
+  openshell:
+    source_profiles:
+    - ocsf.file
+    - ocsf.forwarded
+    - openshell.log
+    - openshell.log.forwarded
+    - watchsandbox
+    - policy.reconciliation
+    - nemo_relay.log
+    - nemo_relay.trace
+    - openshell.trace
+    - kubernetes.context
+    gateway_id: gateway-1
+    workspace: default
+    source_instance: gateway-evidence
+    default_sandbox_id: unknown
+    validation:
+      mode: mark
+    redaction:
+      profile_id: openshell-default
+      version: '1'
+      keys:
+      - access_token
+      - api_key
+      - authorization
+      - client_secret
+      - password
+      - refresh_token
+      - secret
+      patterns:
+      - (?i)\bBearer\s+[A-Za-z0-9._~+/-]+=*
+      - (?i)\b(api[_-]?key|password|secret)\s*[:=]\s*[^\s,;]+
+    correlation_fields:
+    - metadata.original_event_uid
+    - unmapped.correlation_id
+    - unmapped.policy_chunk_id
+  resource/nemo_relay:
+    attributes:
+    - key: telemetry.source
+      value: nemo_relay
+      action: upsert
+    - key: openshell.gateway.id
+      value: gateway-1
+      action: upsert
+    - key: openshell.workspace
+      value: default
+      action: upsert
+  # All Relay settings. allow mode keeps approved metadata and removes unknown
+  # attributes and content. Patterns use glob syntax. Required correlation keys
+  # must be protected attributes. aliases maps canonical key -> source alias.
+  relay/nemo_relay:
+    gateway_id: gateway-1
+    workspace: default
+    telemetry_source: nemo_relay
+    canonicalize_span_names: true
+    required_correlation_attributes:
+    - openshell.sandbox.id
+    - agent.session.id
+    privacy:
+      mode: allow
+      allowed_attributes:
+      - deployment.environment
+      - error.category
+      - error.code
+      - error.type
+      - exception.type
+      - gen_ai.conversation.id
+      - gen_ai.operation.name
+      - gen_ai.request.model
+      - gen_ai.response.finish_reasons
+      - gen_ai.response.id
+      - gen_ai.response.model
+      - gen_ai.tool.call.id
+      - gen_ai.usage.*
+      - http.response.status_code
+      - llm.cost.*
+      - llm.model_name
+      - llm.provider
+      - llm.token_count.*
+      - nemo_relay.agent.kind
+      - nemo_relay.llm.cost.*
+      - nemo_relay.mark.parent_uuid
+      - nemo_relay.mark.uuid
+      - nemo_relay.model_name
+      - nemo_relay.scope_type
+      - nemo_relay.session.instance_id
+      - nemo_relay.tool_call_id
+      - nemo_relay.uuid
+      - openinference.span.kind
+      - openshell.sandbox.name
+      - request.id
+      - service.instance.id
+      - service.name
+      - service.namespace
+      - service.version
+      - session.id
+      - telemetry.source
+      - token_type
+      - tokens_in
+      - tokens_out
+      - tool.name
+      - tool_call.function.name
+      - tool_call.id
+      denied_attributes:
+      - '*authorization*'
+      - '*credential*'
+      - '*input*'
+      - '*output*'
+      - '*password*'
+      - '*prompt*'
+      - '*response*content*'
+      - '*secret*'
+      - '*token*'
+      - '*tool*argument*'
+      - '*tool*result*'
+    aliases:
+      agent.session.id: session.id
+      openshell.policy.version: policy.version
+      request_id: gen_ai.request.id
+      tool_call_id: nemo_relay.tool_call_id
+  resource/openshell_native:
+    attributes:
+    - key: telemetry.source
+      value: openshell_native
+      action: upsert
+    - key: openshell.gateway.id
+      value: gateway-1
+      action: upsert
+    - key: openshell.workspace
+      value: default
+      action: upsert
+  # Native OpenShell traces use a distinct profile. deny mode preserves unknown
+  # attributes, so use only for authorized native telemetry, never Relay content.
+  relay/openshell_native:
+    gateway_id: gateway-1
+    workspace: default
+    telemetry_source: openshell_native
+    canonicalize_span_names: false
+    required_correlation_attributes: []
+    privacy:
+      mode: deny
+      allowed_attributes:
+      - deployment.environment
+      - error.category
+      - error.code
+      - error.type
+      - exception.type
+      - gen_ai.conversation.id
+      - gen_ai.operation.name
+      - gen_ai.request.model
+      - gen_ai.response.finish_reasons
+      - gen_ai.response.id
+      - gen_ai.response.model
+      - gen_ai.tool.call.id
+      - gen_ai.usage.*
+      - http.response.status_code
+      - llm.cost.*
+      - llm.model_name
+      - llm.provider
+      - llm.token_count.*
+      - nemo_relay.agent.kind
+      - nemo_relay.llm.cost.*
+      - nemo_relay.mark.parent_uuid
+      - nemo_relay.mark.uuid
+      - nemo_relay.model_name
+      - nemo_relay.scope_type
+      - nemo_relay.session.instance_id
+      - nemo_relay.tool_call_id
+      - nemo_relay.uuid
+      - openinference.span.kind
+      - openshell.sandbox.name
+      - request.id
+      - service.instance.id
+      - service.name
+      - service.namespace
+      - service.version
+      - session.id
+      - telemetry.source
+      - token_type
+      - tokens_in
+      - tokens_out
+      - tool.name
+      - tool_call.function.name
+      - tool_call.id
+      denied_attributes:
+      - '*authorization*'
+      - '*credential*'
+      - '*input*'
+      - '*output*'
+      - '*password*'
+      - '*prompt*'
+      - '*response*content*'
+      - '*secret*'
+      - '*token*'
+      - '*tool*argument*'
+      - '*tool*result*'
+    aliases:
+      agent.session.id: session.id
+      openshell.policy.version: policy.version
+      request_id: gen_ai.request.id
+      tool_call_id: nemo_relay.tool_call_id
+  attributes/forwarded_files:
+    actions:
+    - key: openshell.acquisition.source_instance
+      value: sandbox-ocsf-forwarder
+      action: insert
+    - key: openshell.acquisition.transport
+      value: otlp_http
+      action: upsert
+  # Edge only: stamp AFTER openshell (logs) or relay (traces), then forward to
+  # central over authenticated mTLS. mode is stamp or verify; version is 1.0.
+  # tenant_id: [a-z0-9][a-z0-9._-]{0,62}. A contract is not authentication.
+  evidencecontract/stamp:
+    mode: stamp
+    contract_version: '1.0'
+    tenant_id: default
+  # Central only: verify the trusted internal stream before final delivery.
+  # Do not normalize again or stamp and verify in the same pipeline.
+  evidencecontract/verify:
+    mode: verify
+    contract_version: '1.0'
+    tenant_id: default
+  attributes/kubernetes_context:
+    actions:
+    - key: openshell.acquisition.kind
+      value: kubernetes.context
+      action: upsert
+exporters:
+  otlp:
+    endpoint: otel.example.com:4317
+    auth:
+      authenticator: bearertokenauth/otlp_destination
+    tls:
+      ca_file: /run/secrets/otlp-ca.pem
+      cert_file: ''
+      key_file: ''
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+      initial_interval: 1s
+      max_interval: 30s
+    sending_queue:
+      enabled: true
+      storage: file_storage/otlp_queue
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 512
+        max_size: 1024
+        sizer: items
+  otlphttp:
+    endpoint: https://otel.example.com:4318
+    auth:
+      authenticator: bearertokenauth/otlp_destination
+    tls:
+      ca_file: /run/secrets/otlp-ca.pem
+      cert_file: ''
+      key_file: ''
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+      initial_interval: 1s
+      max_interval: 30s
+    sending_queue:
+      enabled: true
+      storage: file_storage/otlphttp_queue
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 512
+        max_size: 1024
+        sizer: items
+  # All CloudEvents-specific settings plus HTTP/auth/TLS and durable delivery.
+  # max_events: 1..500, max_event_bytes <= 1 MiB, max_request_bytes <= 4 MiB
+  # and >= max_event_bytes + 2. default_source is the fallback source URI.
+  # HTTP is for local fixtures only; credentials/headers require HTTPS.
+  # TLS insecure/insecure_skip_verify are rejected. Supply trusted CAs instead.
+  # Each destination needs its own queue. This queue counts requests, not minutes.
+  cloudevents:
+    endpoint: https://receiver.example.com/v1/events
+    timeout: 15s
+    max_events: 500
+    max_event_bytes: 1048576
+    max_request_bytes: 4194304
+    auth:
+      authenticator: bearertokenauth/destination
+    tls:
+      ca_file: /run/secrets/destination-ca.pem
+      cert_file: ''
+      key_file: ''
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 30s
+      max_elapsed_time: 0s
+    sending_queue:
+      enabled: true
+      storage: file_storage/cloudevents_queue
+      sizer: requests
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 512
+        max_size: 1024
+        sizer: items
+    allow_insecure_http: false
+    default_source: openshell://local
+  file/recovery:
+    path: /output/events.json
+    format: json
+    append: true
+  # Optional edge-to-central sharding. Use INSTEAD of final delivery on edge;
+  # each central replica must own private queues. Drain before changing shards.
+  load_balancing/internal:
+    routing_key: attributes
+    routing_attributes:
+    - openshell.exporter.tenant.id
+    - openshell.exporter.shard.key
+    timeout: 15s
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 0s
+    sending_queue:
+      enabled: true
+      storage: file_storage/internal_queue
+      queue_size: 10000
+      num_consumers: 4
+      block_on_overflow: true
+    protocol:
+      otlp:
+        auth:
+          authenticator: bearertokenauth/otlp_destination
+        tls:
+          ca_file: /run/secrets/internal-ca.pem
+          cert_file: /run/secrets/edge.crt
+          key_file: /run/secrets/edge.key
+          server_name_override: central.example.internal
+        retry_on_failure:
+          enabled: true
+          max_elapsed_time: 0s
+    resolver:
+      dns:
+        hostname: central-headless.observability.svc.cluster.local
+        port: '4330'
+        interval: 30s
+        timeout: 5s
+# Declaring a component above does not add it to a pipeline. Add its required
+# auth/storage extensions here when enabling it. Logs -> CloudEvents or OTLP;
+# traces -> OTLP. Avoid double collection of direct and forwarded source files.
+service:
+  telemetry:
+    logs:
+      encoding: json
+    metrics:
+      level: normal
+      readers:
+      - pull:
+          exporter:
+            prometheus:
+              host: 0.0.0.0
+              port: 8888
+  extensions:
+  - file_storage/checkpoints
+  - health_check
+  pipelines:
+    logs/files:
+      receivers:
+      - file_log/openshell_ocsf
+      processors:
+      - memory_limiter
+      - openshell
+      exporters:
+      - file/recovery
+
+    # Optional pipeline examples: enable only the sources you have configured.
+    # logs/gateway:
+    #   receivers: [watchsandbox]
+    #   processors: [memory_limiter, openshell]
+    #   exporters: [cloudevents, file/recovery]
+    # logs/operational:
+    #   receivers: [file_log/openshell_sandbox, file_log/nemo_relay]
+    #   processors: [memory_limiter, openshell]
+    #   exporters: [cloudevents, file/recovery]
+    # logs/forwarded:
+    #   receivers: [otlp/forwarded_ocsf]
+    #   processors: [memory_limiter, attributes/forwarded_files, openshell]
+    #   exporters: [cloudevents, file/recovery]
+    # logs/kubernetes:
+    #   receivers: [k8s_objects]
+    #   processors: [memory_limiter, attributes/kubernetes_context, openshell]
+    #   exporters: [cloudevents, file/recovery]
+    # traces/relay:
+    #   receivers: [otlp/nemo_relay]
+    #   processors: [memory_limiter, resource/nemo_relay, relay/nemo_relay]
+    #   exporters: [otlp]
+    # traces/native:
+    #   receivers: [otlp/openshell_native]
+    #   processors: [memory_limiter, resource/openshell_native, relay/openshell_native]
+    #   exporters: [otlphttp]
+    # logs/central:
+    #   receivers: [otlp/internal]
+    #   processors: [memory_limiter, evidencecontract/verify]
+    #   exporters: [cloudevents, file/recovery]
+    # traces/central:
+    #   receivers: [otlp/internal]
+    #   processors: [memory_limiter, evidencecontract/verify]
+    #   exporters: [otlp]
+    # Edge alternative: append evidencecontract/stamp after the appropriate
+    # normalizer/privacy processor and replace exporters with [load_balancing/internal].

--- a/zensical.toml
+++ b/zensical.toml
@@ -56,7 +56,13 @@ nav = [
       {"Customize profiles" = "documentation/openshell-agent-runner/profiles.md"},
       {"Command reference" = "documentation/openshell-agent-runner/reference.md"}
     ]},
-    {"OpenShell Event Exporter" = "documentation/openshell-exporter/index.md"}
+    {"OpenShell Event Exporter" = [
+      "documentation/openshell-exporter/index.md",
+      {"Docker" = "documentation/openshell-exporter/docker.md"},
+      {"Podman" = "documentation/openshell-exporter/podman.md"},
+      {"Helm" = "documentation/openshell-exporter/helm.md"},
+      {"Configure sources and delivery" = "documentation/openshell-exporter/configuration.md"}
+    ]}
   ]}
 ]
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,7 +55,8 @@ nav = [
       {"Run reviews" = "documentation/openshell-agent-runner/reviews.md"},
       {"Customize profiles" = "documentation/openshell-agent-runner/profiles.md"},
       {"Command reference" = "documentation/openshell-agent-runner/reference.md"}
-    ]}
+    ]},
+    {"OpenShell Event Exporter" = "documentation/openshell-exporter/index.md"}
   ]}
 ]
 


### PR DESCRIPTION
Add a small exporter landing page and step-by-step installation instructions for Docker, rootless Podman, and the exporter’s own Helm chart. Users consume public GHCR images and the packaged chart without access to the private implementation repository. The same image reference selects Linux AMD64 or ARM64; Apple Silicon runs the Linux ARM64 image through its container VM.

The Helm guide uses the maintained `deploy/kubernetes/chart/` package from `oci://ghcr.io/nvidia/charts/openshell-event-exporter`, with a small values file, source/destination Secrets, and separate persistent volumes. Add `template.config.yaml` containing every exporter-specific setting and examples for all 19 included component types; keep advanced upstream transport/parser options outside the reference. Research contains documentation and configuration assets only. No scripts or shared CI changes are added.

Validation:
- Research documentation tests: 23 passed, 3 rendered-site-only skips; strict site build and all post-build checks passed. Built pages and configuration downloads verified through the local preview.
- Configuration template and its optional pipelines validated using the actual exporter image and synthetic secrets; coverage checked against exporter-owned YAML keys and bundled component types.
- Native Helm chart lint/package/render and isolated Kubernetes install, restart, health, and three-PVC retention after uninstall passed. This used the local AMD64 image and synthetic credentials, with no live gateway delivery claim.
- Docker Compose and rootless Podman quickstart collection/restart checks passed in the preceding revision; their commands and configurations are unchanged here.

Keep this PR draft until public image/chart publication and anonymous pull verification succeed. ARM64 and Apple Silicon execution have not been rerun locally. The landing page explicitly marks the release as pending.
